### PR TITLE
Historical data sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,24 +91,27 @@ ibkrEvents.on(IBKREVENTS.PORTFOLIOS, (porfolios: PortFolioUpdate[]) => {
 import { HistoricalData } from '@stoqey/ibkr';
 
 // 1. Init
-HistoricalData.Instance;
+const historyApi = HistoricalData.Instance;
 
 const args = {
   symbol,
-  contract = [symbol, 'SMART', 'USD'],
+  // contract: ib.contract.stock("AAPL"),
   endDateTime = '',
   durationStr = '1 D',
   barSizeSetting = '1 min',
   whatToShow = 'ASK'
 };
 
-// 2.1 Request for market data directly
-HistoricalData.Instance.getHistoricalData(args);
+// 2. Get market data async promise
+const data = await historyApi.reqHistoricalData(args);
 
-// 2.2 Request for market using events
-ibkrEvents.emit(IBKREVENTS.GET_MARKET_DATA, args);
+// OR 
 
-// 3. Subscribe to market data results
+// 3.1 Request for market data using events
+historyApi.getHistoricalData(args);
+ibkrEvents.emit(IBKREVENTS.GET_MARKET_DATA, args); // the same
+
+// 3.2. Subscribe to market data results
 ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, ({ symbol, marketData }) => {
     //  Use the data here
 })

--- a/src/contracts/ContractDetails.ts
+++ b/src/contracts/ContractDetails.ts
@@ -4,9 +4,9 @@ import { getRadomReqId } from '../_utils/text.utils';
 import IBKRConnection from '../connection/IBKRConnection';
 import { log } from '../log';
 
-export const getContractDetails = (contracts: string | any): Promise<ContractDetails | ContractDetails[]> => {
+export const getContractDetails = (contract: string | any): Promise<ContractDetails | ContractDetails[]> => {
 
-    let contractArg: any = contracts;
+    let contractArg: any = contract;
     let contractsLocal: ContractDetails[] = [] as any;
 
     let reqId: number = getRadomReqId();
@@ -31,7 +31,7 @@ export const getContractDetails = (contracts: string | any): Promise<ContractDet
             ib.once('contractDetailsEnd', (reqIdX) => {
                 if (reqId === reqIdX) {
                     ib.off('contractDetails', handleContract);
-                    if (typeof contracts === "string") {
+                    if (typeof contract === "string") {
                         return resolve(contractsLocal[0])
                     }
                     resolve(contractsLocal);

--- a/src/events/HandleError.ts
+++ b/src/events/HandleError.ts
@@ -1,0 +1,42 @@
+import { IBKRConnection } from "../connection";
+import isEmpty from "lodash/isEmpty";
+
+/**
+ * Assuming IBKR returns predictable errors
+ * Check if errors thrown match the targetError,
+ * @param targetErrors - target strings,
+ * @param catchError - function to stop/tell caller that targetErrors where matched
+ * 
+ * @returns () => void // remove listener function
+ * @important always call the returned function to remove listeners and avoid memory leaks
+ */
+export function handleEventfulError(targetErrors: string[], catchError: Function): () => void {
+
+    if (isEmpty(targetErrors)) {
+        return () => { };
+    };
+
+    // convert all targeted errors to lowercase
+    targetErrors = targetErrors.map(er => (er || "").toLowerCase());
+
+    const ib = IBKRConnection.Instance.getIBKR();
+
+    const handleError = (error) => {
+        // message to lower case
+        const errorMessage = (error && error.message || "").toLowerCase();
+
+        const isError = targetErrors.some(tError => errorMessage.includes(tError));
+
+        if (isError) {
+            console.log('error message', errorMessage);
+            catchError();
+        }
+    };
+
+    ib.on('error', handleError);
+
+    // return remover 
+    return () => {
+        ib.off('error', handleError);
+    }
+}

--- a/src/events/HandleError.ts
+++ b/src/events/HandleError.ts
@@ -1,5 +1,6 @@
 import { IBKRConnection } from "../connection";
 import isEmpty from "lodash/isEmpty";
+import { verbose } from "../log";
 
 /**
  * Assuming IBKR returns predictable errors
@@ -28,7 +29,7 @@ export function handleEventfulError(targetErrors: string[], catchError: Function
         const isError = targetErrors.some(tError => errorMessage.includes(tError));
 
         if (isError) {
-            console.log('error message', errorMessage);
+            verbose('handleEventfulError > handleError.errorMessage', errorMessage);
             catchError();
         }
     };

--- a/src/history/history.data.ts
+++ b/src/history/history.data.ts
@@ -59,8 +59,7 @@ export class HistoricalData {
       const allCollectedData = this.historyDataDump[tickerId] && this.historyDataDump[tickerId].data || [];
 
       // sort data by date
-
-      const collectedData = !isEmpty(allCollectedData) ? sortedMarketData(allCollectedData) : allCollectedData;
+      const collectedData = sortedMarketData(allCollectedData);
 
       this.historyData = {
         ...this.historyData,

--- a/src/history/history.data.ts
+++ b/src/history/history.data.ts
@@ -9,6 +9,7 @@ import IBKRConnection from '../connection/IBKRConnection';
 import { IbkrEvents, publishDataToTopic, IBKREVENTS } from '../events';
 import { HistoryData, SymbolWithTicker, ReqHistoricalData, SymbolWithMarketData, WhatToShow, BarSizeSetting } from './history.interfaces';
 import { log } from '../log';
+import { sortedMarketData } from './history.utils';
 
 
 const appEvents = IbkrEvents.Instance;
@@ -55,7 +56,11 @@ export class HistoricalData {
         return null;
       }
 
-      const collectedData = reverse(this.historyDataDump[tickerId] && this.historyDataDump[tickerId].data || []);
+      const allCollectedData = this.historyDataDump[tickerId] && this.historyDataDump[tickerId].data || [];
+
+      // sort data by date
+
+      const collectedData = !isEmpty(allCollectedData) ? sortedMarketData(allCollectedData) : allCollectedData;
 
       this.historyData = {
         ...this.historyData,
@@ -228,7 +233,7 @@ export class HistoricalData {
           done = true;
           ib.off('historicalData', onHistoricalData)
           ib.cancelHistoricalData(tickerId);  // tickerId
-          const collectedData = reverse(marketData);
+          const collectedData = sortedMarketData(marketData);
           resolve(collectedData);
         }
       }

--- a/src/history/history.interfaces.ts
+++ b/src/history/history.interfaces.ts
@@ -4,7 +4,7 @@ export type WhatToShow = "ADJUSTED_LAST" | "TRADES" | "MIDPOINT" | "BID" | "ASK"
 export type BarSizeSetting = "1 secs" | "5 secs" | "10 secs" | "15 secs" | "30 secs" | "1 min" | "2 mins" | "3 mins" | "5 mins" | "10 mins" | "15 mins" | "20 mins" | "30 mins" | "1 hour" | "2 hours" | "3 hours" | "4 hours" | "8 hours" | "1 day" | "1W" | "1M";
 export interface HistoryData {
     reqId?: number;
-    date: Date; // "20190308  11:59:56"
+    date: Date;
     open?: number;
     high?: number;
     low?: number;
@@ -16,7 +16,7 @@ export interface HistoryData {
 }
 
 export interface ReqHistoricalData {
-    contract: string[] | object | string // "IFRX", "SMART", "USD",
+    contract: string | object // "IFRX", "SMART", "USD",
     endDateTime: string; // "20190308 12:00:00",
     durationStr: string; // "1800 S"
     barSizeSetting: BarSizeSetting; // "1 secs"

--- a/src/history/history.test.ts
+++ b/src/history/history.test.ts
@@ -30,14 +30,18 @@ describe('Historical Data', () => {
 
         let complete = false;
         HistoricalData.Instance.getHistoricalData({
-            symbol, whatToShow: "BID",
-            durationStr: '1800 S',
-            barSizeSetting: '1 secs',
+            endDateTime: '20200521 15:00:00',
+            symbol,
+            whatToShow: "BID",
+            durationStr: '3600 S',
+            barSizeSetting: '5 secs',
         });
 
-        ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }) => {
+        ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }: { symbol: string; marketData: any[] }) => {
             // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
             log(`Historical Data for ${symbol} ${data && data.length}`);
+            log(`Start ----> ${symbol} ${data.shift().date}`);
+            log(`End ----> ${symbol} ${data.pop().date}`);
             if (!complete) {
                 complete = true;
                 done();
@@ -45,80 +49,85 @@ describe('Historical Data', () => {
         })
     });
 
-    it('should get market data with contract object', (done) => {
-        const symbol = "AAPL";
+    // it('should get market data with contract object', (done) => {
+    //     const symbol = "AAPL";
 
-        const ib = IBKRConnection.Instance.getIBKR();
+    //     const ib = IBKRConnection.Instance.getIBKR();
 
-        let complete = false;
+    //     let complete = false;
 
-        setTimeout(() => {
-            // To avoid violation pace
-            HistoricalData.Instance.getHistoricalData({
-                contract: ib.contract.stock("AAPL"),
-                symbol,
-                whatToShow: "BID",
-                durationStr: '1800 S',
-                barSizeSetting: '1 secs',
-            });
-        }, 3000);
+    //     setTimeout(() => {
+    //         // To avoid violation pace
+    //         HistoricalData.Instance.getHistoricalData({
+
+    //             contract: ib.contract.stock("AAPL"),
+    //             symbol,
+    //             whatToShow: "BID",
+    //             durationStr: '1800 S',
+    //             barSizeSetting: '1 secs',
+    //         });
+    //     }, 3000);
 
 
-        ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }) => {
-            // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
-            log(`Historical Data for ${symbol} ${data && data.length}`);
-            if (!complete) {
-                complete = true;
-                done();
-            }
-        })
-    });
+    //     ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }) => {
+    //         // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
+    //         log(`Historical Data for ${symbol} ${data && data.length}`);
+    //         if (!complete) {
+    //             complete = true;
+    //             done();
+    //         }
+    //     })
+    // });
 
     it('should get market data async mode', (done) => {
         const symbol = "AAPL";
 
         async function getMarketData() {
             const data = await HistoricalData.Instance.reqHistoricalData({
+                endDateTime: '20200521 15:00:00',
                 symbol, whatToShow: "BID",
                 durationStr: '1800 S',
                 barSizeSetting: '1 secs',
             });
 
             log(`Historical Data for ${symbol} ${data && data.length}`);
+            log(`Start ----> ${symbol} ${data.shift().date}`);
+            log(`End ----> ${symbol} ${data.pop().date}`);
+
             done();
         }
 
         setTimeout(() => {
             getMarketData();
-        }, 3000);
+        }, 1000);
 
 
     });
 
-    it('should get market data async mode with contract object', (done) => {
-        const symbol = "AAPL";
+    // it('should get market data async mode with contract object', (done) => {
+    //     const symbol = "AAPL";
 
-        const ib = IBKRConnection.Instance.getIBKR();
+    //     const ib = IBKRConnection.Instance.getIBKR();
 
-        async function getMarketData() {
-            const data = await HistoricalData.Instance.reqHistoricalData({
-                symbol,
-                whatToShow: "BID",
-                contract: ib.contract.stock("AAPL"),
-                durationStr: '1800 S',
-                barSizeSetting: '1 secs',
-            });
+    //     async function getMarketData() {
+    //         const data = await HistoricalData.Instance.reqHistoricalData({
+    //             symbol,
+    //             whatToShow: "BID",
+    //             contract: ib.contract.stock("AAPL"),
+    //             durationStr: '1800 S',
+    //             barSizeSetting: '1 secs',
+    //         });
 
-            log(`Historical Data for ${symbol} ${data && data.length}`);
-            done();
-        }
+    //         log(`Historical Data for ${symbol} ${data && data.length}`);
+    //         done();
+    //     }
 
-        setTimeout(() => {
-            getMarketData();
-        }, 3000);
+    //     setTimeout(() => {
+    //         getMarketData();
+    //     }, 3000);
 
 
-    });
+    // });
 })
 
 

--- a/src/history/history.test.ts
+++ b/src/history/history.test.ts
@@ -25,29 +25,29 @@ before((done) => {
 
 describe('Historical Data', () => {
 
-    it('should get market data', (done) => {
-        const symbol = "AAPL";
+    // it('should get market data', (done) => {
+    //     const symbol = "AAPL";
 
-        let complete = false;
-        HistoricalData.Instance.getHistoricalData({
-            endDateTime: '20200521 15:00:00',
-            symbol,
-            whatToShow: "BID",
-            durationStr: '3600 S',
-            barSizeSetting: '5 secs',
-        });
+    //     let complete = false;
+    //     HistoricalData.Instance.getHistoricalData({
+    //         endDateTime: '20200521 15:00:00',
+    //         symbol,
+    //         whatToShow: "BID",
+    //         durationStr: '3600 S',
+    //         barSizeSetting: '5 secs',
+    //     });
 
-        ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }: { symbol: string; marketData: any[] }) => {
-            // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
-            log(`Historical Data for ${symbol} ${data && data.length}`);
-            log(`Start ----> ${symbol} ${data.shift().date}`);
-            log(`End ----> ${symbol} ${data.pop().date}`);
-            if (!complete) {
-                complete = true;
-                done();
-            }
-        })
-    });
+    //     ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }: { symbol: string; marketData: any[] }) => {
+    //         // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
+    //         log(`Historical Data for ${symbol} ${data && data.length}`);
+    //         log(`Start ----> ${symbol} ${data.shift().date}`);
+    //         log(`End ----> ${symbol} ${data.pop().date}`);
+    //         if (!complete) {
+    //             complete = true;
+    //             done();
+    //         }
+    //     })
+    // });
 
     // it('should get market data with contract object', (done) => {
     //     const symbol = "AAPL";
@@ -79,30 +79,30 @@ describe('Historical Data', () => {
     //     })
     // });
 
-    it('should get market data async mode', (done) => {
-        const symbol = "AAPL";
+    // it('should get market data async mode', (done) => {
+    //     const symbol = "AAPL";
 
-        async function getMarketData() {
-            const data = await HistoricalData.Instance.reqHistoricalData({
-                endDateTime: '20200521 15:00:00',
-                symbol, whatToShow: "BID",
-                durationStr: '1800 S',
-                barSizeSetting: '1 secs',
-            });
+    //     async function getMarketData() {
+    //         const data = await HistoricalData.Instance.reqHistoricalData({
+    //             endDateTime: '20200521 15:00:00',
+    //             symbol, whatToShow: "BID",
+    //             durationStr: '1800 S',
+    //             barSizeSetting: '1 secs',
+    //         });
 
-            log(`Historical Data for ${symbol} ${data && data.length}`);
-            log(`Start ----> ${symbol} ${data.shift().date}`);
-            log(`End ----> ${symbol} ${data.pop().date}`);
+    //         log(`Historical Data for ${symbol} ${data && data.length}`);
+    //         log(`Start ----> ${symbol} ${data.shift().date}`);
+    //         log(`End ----> ${symbol} ${data.pop().date}`);
 
-            done();
-        }
+    //         done();
+    //     }
 
-        setTimeout(() => {
-            getMarketData();
-        }, 1000);
+    //     setTimeout(() => {
+    //         getMarketData();
+    //     }, 1000);
 
 
-    });
+    // });
 
     // it('should get market data async mode with contract object', (done) => {
     //     const symbol = "AAPL";
@@ -128,6 +128,28 @@ describe('Historical Data', () => {
 
 
     // });
+
+    it('should get empty market data contract object is invalid', (done) => {
+        const symbol = "AAPL";
+
+        async function getMarketData() {
+            const data = await HistoricalData.Instance.reqHistoricalData({
+                symbol,
+                durationStr: '1 W',
+                barSizeSetting: '1 day',
+                whatToShow: 'YIELD_BID'
+            });
+
+            log(`Historical Data for ${symbol} ${data && data.length}`);
+            done();
+        }
+
+        setTimeout(() => {
+            getMarketData();
+        }, 3000);
+
+
+    });
 })
 
 

--- a/src/history/history.test.ts
+++ b/src/history/history.test.ts
@@ -25,109 +25,109 @@ before((done) => {
 
 describe('Historical Data', () => {
 
-    // it('should get market data', (done) => {
-    //     const symbol = "AAPL";
+    it('should get market data', (done) => {
+        const symbol = "AAPL";
 
-    //     let complete = false;
-    //     HistoricalData.Instance.getHistoricalData({
-    //         endDateTime: '20200521 15:00:00',
-    //         symbol,
-    //         whatToShow: "BID",
-    //         durationStr: '3600 S',
-    //         barSizeSetting: '5 secs',
-    //     });
+        let complete = false;
+        HistoricalData.Instance.getHistoricalData({
+            endDateTime: '20200521 15:00:00',
+            symbol,
+            whatToShow: "BID",
+            durationStr: '3600 S',
+            barSizeSetting: '5 secs',
+        });
 
-    //     ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }: { symbol: string; marketData: any[] }) => {
-    //         // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
-    //         log(`Historical Data for ${symbol} ${data && data.length}`);
-    //         log(`Start ----> ${symbol} ${data.shift().date}`);
-    //         log(`End ----> ${symbol} ${data.pop().date}`);
-    //         if (!complete) {
-    //             complete = true;
-    //             done();
-    //         }
-    //     })
-    // });
+        ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }: { symbol: string; marketData: any[] }) => {
+            // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
+            log(`Historical Data for ${symbol} ${data && data.length}`);
+            log(`Start ----> ${symbol} ${data.shift().date}`);
+            log(`End ----> ${symbol} ${data.pop().date}`);
+            if (!complete) {
+                complete = true;
+                done();
+            }
+        })
+    });
 
-    // it('should get market data with contract object', (done) => {
-    //     const symbol = "AAPL";
+    it('should get market data with contract object', (done) => {
+        const symbol = "AAPL";
 
-    //     const ib = IBKRConnection.Instance.getIBKR();
+        const ib = IBKRConnection.Instance.getIBKR();
 
-    //     let complete = false;
+        let complete = false;
 
-    //     setTimeout(() => {
-    //         // To avoid violation pace
-    //         HistoricalData.Instance.getHistoricalData({
+        setTimeout(() => {
+            // To avoid violation pace
+            HistoricalData.Instance.getHistoricalData({
 
-    //             contract: ib.contract.stock("AAPL"),
-    //             symbol,
-    //             whatToShow: "BID",
-    //             durationStr: '1800 S',
-    //             barSizeSetting: '1 secs',
-    //         });
-    //     }, 3000);
-
-
-    //     ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }) => {
-    //         // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
-    //         log(`Historical Data for ${symbol} ${data && data.length}`);
-    //         if (!complete) {
-    //             complete = true;
-    //             done();
-    //         }
-    //     })
-    // });
-
-    // it('should get market data async mode', (done) => {
-    //     const symbol = "AAPL";
-
-    //     async function getMarketData() {
-    //         const data = await HistoricalData.Instance.reqHistoricalData({
-    //             endDateTime: '20200521 15:00:00',
-    //             symbol, whatToShow: "BID",
-    //             durationStr: '1800 S',
-    //             barSizeSetting: '1 secs',
-    //         });
-
-    //         log(`Historical Data for ${symbol} ${data && data.length}`);
-    //         log(`Start ----> ${symbol} ${data.shift().date}`);
-    //         log(`End ----> ${symbol} ${data.pop().date}`);
-
-    //         done();
-    //     }
-
-    //     setTimeout(() => {
-    //         getMarketData();
-    //     }, 1000);
+                contract: ib.contract.stock("AAPL"),
+                symbol,
+                whatToShow: "BID",
+                durationStr: '1800 S',
+                barSizeSetting: '1 secs',
+            });
+        }, 3000);
 
 
-    // });
+        ibkrEvents.on(IBKREVENTS.ON_MARKET_DATA, async ({ symbol, marketData: data }) => {
+            // await fsPromises.writeFile(`${__dirname}/${symbol}.json`, JSON.stringify(data));
+            log(`Historical Data for ${symbol} ${data && data.length}`);
+            if (!complete) {
+                complete = true;
+                done();
+            }
+        })
+    });
 
-    // it('should get market data async mode with contract object', (done) => {
-    //     const symbol = "AAPL";
+    it('should get market data async mode', (done) => {
+        const symbol = "AAPL";
 
-    //     const ib = IBKRConnection.Instance.getIBKR();
+        async function getMarketData() {
+            const data = await HistoricalData.Instance.reqHistoricalData({
+                endDateTime: '20200521 15:00:00',
+                symbol, whatToShow: "BID",
+                durationStr: '1800 S',
+                barSizeSetting: '1 secs',
+            });
 
-    //     async function getMarketData() {
-    //         const data = await HistoricalData.Instance.reqHistoricalData({
-    //             symbol,
-    //             whatToShow: "BID",
-    //             contract: ib.contract.stock("AAPL"),
-    //             durationStr: '1800 S',
-    //             barSizeSetting: '1 secs',
-    //         });
+            log(`Historical Data for ${symbol} ${data && data.length}`);
+            log(`Start ----> ${symbol} ${data.shift().date}`);
+            log(`End ----> ${symbol} ${data.pop().date}`);
 
-    //         log(`Historical Data for ${symbol} ${data && data.length}`);
-    //         done();
-    //     }
+            done();
+        }
 
-    //     setTimeout(() => {
-    //         getMarketData();
-    //     }, 3000);
+        setTimeout(() => {
+            getMarketData();
+        }, 1000);
 
 
-    // });
+    });
+
+    it('should get market data async mode with contract object', (done) => {
+        const symbol = "AAPL";
+
+        const ib = IBKRConnection.Instance.getIBKR();
+
+        async function getMarketData() {
+            const data = await HistoricalData.Instance.reqHistoricalData({
+                symbol,
+                whatToShow: "BID",
+                contract: ib.contract.stock("AAPL"),
+                durationStr: '1800 S',
+                barSizeSetting: '1 secs',
+            });
+
+            log(`Historical Data for ${symbol} ${data && data.length}`);
+            done();
+        }
+
+        setTimeout(() => {
+            getMarketData();
+        }, 3000);
+
+
+    });
 
     it('should get empty market data contract object is invalid', (done) => {
         const symbol = "AAPL";

--- a/src/history/history.utils.ts
+++ b/src/history/history.utils.ts
@@ -1,0 +1,10 @@
+import uniqBy from 'lodash/uniqBy';
+import isEmpty from 'lodash/isEmpty';
+import { HistoryData } from './history.interfaces';
+
+export const sortedMarketData = (data: HistoryData[]): HistoryData[] => !isEmpty(data) ? uniqBy(data, 'date').sort((a, b) => {
+    if (new Date(a.date) > new Date(b.date)) {
+        return 1;
+    }
+    return -1;
+}) : [];


### PR DESCRIPTION
- sort market data return when `reqHistoricalData`
- listen if any errors are thrown when   `reqHistoricalData`, then return empty market data and avoid deadlock like in #25 