### PR TITLE
add getSecDefOptParams() to get summary of available options

### DIFF
--- a/src/contracts/contracts.test.ts
+++ b/src/contracts/contracts.test.ts
@@ -5,6 +5,7 @@ import {log} from '../log';
 import {IBKRConnection} from '../connection';
 import dotenv from 'dotenv';
 import {getContractDetailsOne, getContractDetailsOneOrNone, getContractSummaryOne} from '.';
+import {getSecDefOptParams} from './getSecDefOptParams';
 
 before(async () => {
     dotenv.config({path: '.env.test'});
@@ -101,7 +102,7 @@ describe('Contracts', () => {
             currency: 'USD',
             exchange: 'SMART',
             multiplier: 100,
-            expiry: "20210129",
+            expiry: '20210129',
             strike: 13.5,
             right: 'P',
             secType: 'OPT',
@@ -131,6 +132,19 @@ describe('Contracts', () => {
             log('contract ', JSON.stringify(contractDetails));
         } else {
             throw Error('Error getting symbol details');
+        }
+    });
+
+    it('getSecDefOptParams() should get an overview of options', async () => {
+        const datas = await getSecDefOptParams({
+            conId: 35111040,
+            secType: 'STK',
+            symbol: 'MPW',
+        });
+        if (datas) {
+            log('option overview:', JSON.stringify(datas));
+        } else {
+            throw Error('Error getting option overview');
         }
     });
 });

--- a/src/contracts/getSecDefOptParams.ts
+++ b/src/contracts/getSecDefOptParams.ts
@@ -1,0 +1,86 @@
+import {IBKRConnection} from '../connection';
+import {log} from '../log';
+import {getRadomReqId} from '../_utils/text.utils';
+import {SecType} from './contracts.interfaces';
+
+export interface SecDefOptContractParams {
+    readonly conId: number;
+    readonly secType: SecType | string;
+    readonly symbol: string;
+    readonly futFopExchange?: string;
+}
+
+export interface SecDefOptData {
+    /** The exchange for the option */
+    readonly exchange: string;
+    /** Underlying conId */
+    readonly underlyingConId: number;
+    /** Underlying symbol */
+    readonly tradingClass: string;
+    /** The multiplier as a string, typically "100" */
+    readonly multiplier: string;
+    /** List of expiration dates in YYYYMMDD format */
+    readonly expirations: readonly string[];
+    /** List of strike prices */
+    readonly strikes: readonly number[];
+}
+
+export function getSecDefOptParams(
+    contract: SecDefOptContractParams
+): Promise<readonly SecDefOptData[]> {
+    const ib = IBKRConnection.Instance.getIBKR();
+
+    const datas: SecDefOptData[] = [];
+
+    const reqIdSelected = getRadomReqId();
+
+    let resolver: undefined | ((value: readonly SecDefOptData[]) => void);
+
+    const dataHandler = (
+        reqId: number,
+        exchange: string,
+        underlyingConId: number,
+        tradingClass: string,
+        multiplier: string,
+        expirations: readonly string[],
+        strikes: readonly number[]
+    ) => {
+        if (reqId === reqIdSelected) {
+            const data: SecDefOptData = {
+                exchange,
+                underlyingConId,
+                tradingClass,
+                multiplier,
+                expirations,
+                strikes,
+            };
+
+            log('onSecDefOptParams:', reqId, data);
+
+            datas.push(data);
+        }
+    };
+
+    const endHandler = (reqId: number) => {
+        if (reqId === reqIdSelected) {
+            log('onSecDefOptParamsEnd:', reqId);
+            ib.off('securityDefinitionOptionParameter', dataHandler);
+            ib.off('securityDefinitionOptionParameterEnd', endHandler);
+            resolver?.(datas);
+        }
+    };
+
+    ib.on('securityDefinitionOptionParameter', dataHandler);
+    ib.on('securityDefinitionOptionParameterEnd', endHandler);
+    ib.reqSecDefOptParams(
+        reqIdSelected,
+        contract.symbol,
+        contract.futFopExchange ?? '',
+        contract.secType,
+        contract.conId
+    );
+
+    return new Promise<readonly SecDefOptData[]>((res) => {
+        resolver = res;
+    });
+}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,2 +1,3 @@
 export * from './ContractDetails';
 export * from './contracts.interfaces';
+export * from './getSecDefOptParams';


### PR DESCRIPTION
This implements `getSecDefOptParams()`, encapsulating the `reqSecDefOptParams` API to get a summary of available options.