### PR TITLE
fix: properly wait for async calls to finish

### DIFF
--- a/src/connection/IBKRConnection.ts
+++ b/src/connection/IBKRConnection.ts
@@ -102,7 +102,6 @@ export class IBKRConnection {
         // connect to IBKR
         if (this.connected) {
             await this.initializeDep();
-            return true;
         }
 
         this.errors = this.ibApiNext.errorSubject.subscribe((error: any) => {
@@ -175,6 +174,7 @@ export class IBKRConnection {
 
         });
 
+        return true;
     }
 
     disconnect() {

--- a/src/connection/IBKRConnection.ts
+++ b/src/connection/IBKRConnection.ts
@@ -121,7 +121,6 @@ export class IBKRConnection {
                     this.connected = true;
                     log('connected to ibkr');
                     return true;
-                    break;
                 case ConnectionState.Disconnected:
                     log('disconnected from ibkr', this.connectionState);
                     this.connected = false;

--- a/src/connection/IBKRConnection.ts
+++ b/src/connection/IBKRConnection.ts
@@ -101,7 +101,7 @@ export class IBKRConnection {
 
         // connect to IBKR
         if (this.connected) {
-            this.initializeDep();
+            await this.initializeDep();
             return true;
         }
 


### PR DESCRIPTION
removes the `return new Promise((resolve) => {` wrapper as it servers no purpose here - the function is async, so it by default returns a promise, having it wrapped in another promise caused issue when calling `this.initializeDep();` without await - the connect function finished even though initializeDep has not yet finished