### PR TITLE
fix(`getHistoricalTicksLast`): Fix dates

### DIFF
--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -236,17 +236,19 @@ export class MarketDataManager {
         return null;
     };
 
-    getHistoricalTicksLast = async (contract: Contract, startDate: Date | "" = "", endDate: Date | "" = "", numberOfTicks = 1000, useRTH = false): Promise<TickByTickAllLast[]> => {
-        if (startDate && endDate) {
-            warn("getHistoricalTicksLast only set either startDate or endDate, not both");
-            return null;
-        } else if (!endDate && !startDate) {
-            warn("getHistoricalTicksLast please set endDate or startDate");
+    getHistoricalTicksLast = async (contract: Contract, startDate: Date | string, endDate?: Date | string, numberOfTicks = 1000, useRTH = false): Promise<TickByTickAllLast[]> => {
+        if (!startDate) {
+            warn("getHistoricalTicksLast startDate not set");
             return null;
         }
 
-        const startDateTime = startDate ? moment(startDate).format('YYYYMMDD HH:mm:ss') : startDate;
-        const endDateTime = endDate ? moment(endDate).format('YYYYMMDD HH:mm:ss') : endDate;
+        if (endDate && typeof startDate !== 'string' && typeof startDate !== 'string' && startDate > endDate) {
+            warn("getHistoricalTicksLast startDate cannot be great than endDate");
+            return null;
+        }
+
+        const startDateTime = typeof startDate === 'string' ? startDate : moment(startDate).format('YYYYMMDD HH:mm:ss');
+        const endDateTime = typeof endDate === 'string' ? endDate : moment(endDate).format('YYYYMMDD HH:mm:ss');
 
         const [contractInstrument, errContract] = await awaitP(this.getContract(contract));
         if (errContract) {

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -242,7 +242,7 @@ export class MarketDataManager {
             return null;
         }
 
-        if (endDate && typeof startDate !== 'string' && typeof startDate !== 'string' && startDate > endDate) {
+        if (endDate && typeof startDate !== 'string' && typeof endDate !== 'string' && startDate > endDate) {
             warn("getHistoricalTicksLast startDate cannot be great than endDate");
             return null;
         }

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -236,7 +236,7 @@ export class MarketDataManager {
         return null;
     };
 
-    getHistoricalTicksLast = async (contract: Contract, startDate: Date | null, endDate: Date | null, numberOfTicks = 1000, useRTH = false): Promise<TickByTickAllLast[]> => {
+    getHistoricalTicksLast = async (contract: Contract, startDate: Date | "", endDate: Date | "", numberOfTicks = 1000, useRTH = false): Promise<TickByTickAllLast[]> => {
         if (startDate && endDate) {
             warn("getHistoricalTicksLast only set either startDate or endDate, not both");
             return null;

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -236,23 +236,17 @@ export class MarketDataManager {
         return null;
     };
 
-    getHistoricalTicksLast = async (contract: Contract, startDate: Date, endDate: Date, numberOfTicks = 1000, useRTH = false): Promise<TickByTickAllLast[]> => {
-        if (!startDate) {
-            warn("getHistoricalTicksLast startDate not set");
+    getHistoricalTicksLast = async (contract: Contract, startDate: Date | null, endDate: Date | null, numberOfTicks = 1000, useRTH = false): Promise<TickByTickAllLast[]> => {
+        if (startDate && endDate) {
+            warn("getHistoricalTicksLast only set either startDate or endDate, not both");
             return null;
-        }
-        if (!endDate) {
-            warn("getHistoricalTicksLast endDate not set");
-            return null;
-        }
-
-        if(startDate > endDate) {
-            warn("getHistoricalTicksLast startDate cannot be great than endDate");
+        } else if (!endDate && !startDate) {
+            warn("getHistoricalTicksLast please set endDate or startDate");
             return null;
         }
 
-        const startDateTime = moment(startDate).format('YYYYMMDD HH:mm:ss');
-        const endDateTime = moment(endDate).format('YYYYMMDD HH:mm:ss');
+        const startDateTime = startDate ? moment(startDate).format('YYYYMMDD HH:mm:ss') : null;
+        const endDateTime = endDate ? moment(endDate).format('YYYYMMDD HH:mm:ss') : null;
 
         const [contractInstrument, errContract] = await awaitP(this.getContract(contract));
         if (errContract) {

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -245,8 +245,8 @@ export class MarketDataManager {
             return null;
         }
 
-        const startDateTime = startDate ? moment(startDate).format('YYYYMMDD HH:mm:ss') : null;
-        const endDateTime = endDate ? moment(endDate).format('YYYYMMDD HH:mm:ss') : null;
+        const startDateTime = startDate ? moment(startDate).format('YYYYMMDD-HH:mm:ss') : null;
+        const endDateTime = endDate ? moment(endDate).format('YYYYMMDD-HH:mm:ss') : null;
 
         const [contractInstrument, errContract] = await awaitP(this.getContract(contract));
         if (errContract) {

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -236,7 +236,7 @@ export class MarketDataManager {
         return null;
     };
 
-    getHistoricalTicksLast = async (contract: Contract, startDate: Date | "", endDate: Date | "", numberOfTicks = 1000, useRTH = false): Promise<TickByTickAllLast[]> => {
+    getHistoricalTicksLast = async (contract: Contract, startDate: Date | "" = "", endDate: Date | "" = "", numberOfTicks = 1000, useRTH = false): Promise<TickByTickAllLast[]> => {
         if (startDate && endDate) {
             warn("getHistoricalTicksLast only set either startDate or endDate, not both");
             return null;
@@ -245,8 +245,8 @@ export class MarketDataManager {
             return null;
         }
 
-        const startDateTime = startDate ? moment(startDate).format('YYYYMMDD-HH:mm:ss') : null;
-        const endDateTime = endDate ? moment(endDate).format('YYYYMMDD-HH:mm:ss') : null;
+        const startDateTime = startDate ? moment(startDate).format('YYYYMMDD HH:mm:ss') : startDate;
+        const endDateTime = endDate ? moment(endDate).format('YYYYMMDD HH:mm:ss') : endDate;
 
         const [contractInstrument, errContract] = await awaitP(this.getContract(contract));
         if (errContract) {

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -242,7 +242,7 @@ export class MarketDataManager {
             return null;
         }
 
-        if (endDate && typeof startDate !== 'string' && typeof endDate !== 'string' && startDate > endDate) {
+        if (endDate && startDate > endDate) {
             warn("getHistoricalTicksLast startDate cannot be great than endDate");
             return null;
         }


### PR DESCRIPTION
Only one date is allowed in TWS API.

In their docs they use "" for the empty date in Python API and null in C# API. I'm assuming both are ok.

https://interactivebrokers.github.io/tws-api/historical_time_and_sales.html