### PR TITLE
Preserve explicit order field values when parsing orders

### DIFF
--- a/src/orders/Orders.active.test.ts
+++ b/src/orders/Orders.active.test.ts
@@ -162,6 +162,7 @@ describe('IBKR Orders active order cache', () => {
             outsideRth: false,
             transmit: false,
             lmtPrice: 0,
+            auxPrice: Number.NaN,
         }, {
             contract: {
                 symbol: 'NQ',
@@ -176,10 +177,27 @@ describe('IBKR Orders active order cache', () => {
             transmit: false,
             lmtPrice: 0,
         });
+        expect(parsed.order).not.to.have.property('auxPrice');
         expect(parsed.contract).to.deep.equal({
             symbol: 'NQ',
             secType: 'FUT',
             exchange: 'CME',
         });
+    });
+
+    it('should drop NaN order prices when parsing orders', () => {
+        const orders = Orders.Instance as any;
+        const parsed = orders.parseOrder({
+            orderType: OrderType.LMT,
+            lmtPrice: Number.NaN,
+        }, {
+            contract: {
+                symbol: 'NQ',
+                secType: 'FUT',
+                exchange: 'CME',
+            },
+        });
+
+        expect(parsed.order).not.to.have.property('lmtPrice');
     });
 });

--- a/src/orders/Orders.active.test.ts
+++ b/src/orders/Orders.active.test.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import { expect } from 'chai';
 import { of } from 'rxjs';
-import { OrderStatus } from '@stoqey/ib';
+import { OrderStatus, OrderType } from '@stoqey/ib';
 import Orders from './Orders';
 import Portfolios from '../portfolios/Portfolios';
 import { IBKREvents, IBKREVENTS } from '../events';
@@ -153,5 +153,33 @@ describe('IBKR Orders active order cache', () => {
         expect(eventPayload.updatedAt).to.be.a('number');
         expect(observedTradeIds).to.deep.equal(['1001']);
         expect(orders.orders).to.deep.equal([]);
+    });
+
+    it('should preserve explicit false order fields when parsing orders', () => {
+        const orders = Orders.Instance as any;
+        const parsed = orders.parseOrder({
+            orderType: OrderType.LMT,
+            outsideRth: false,
+            transmit: false,
+            lmtPrice: 0,
+        }, {
+            contract: {
+                symbol: 'NQ',
+                secType: 'FUT',
+                exchange: 'CME',
+                primaryExch: '',
+            },
+        });
+
+        expect(parsed.order).to.include({
+            outsideRth: false,
+            transmit: false,
+            lmtPrice: 0,
+        });
+        expect(parsed.contract).to.deep.equal({
+            symbol: 'NQ',
+            secType: 'FUT',
+            exchange: 'CME',
+        });
     });
 });

--- a/src/orders/Orders.ts
+++ b/src/orders/Orders.ts
@@ -16,7 +16,7 @@ import { getContractFilterLabel, isContractAllowed } from '../utils/contract-fil
 
 const ibkrEvents = IBKREvents.Instance;
 
-const hasValue = (value: unknown): boolean => value !== undefined && value !== null && value !== "";
+const hasValue = (value: unknown): boolean => value !== undefined && value !== null && value !== "" && !(typeof value === "number" && Number.isNaN(value));
 
 const ACTIVE_OPEN_ORDER_STATUSES = new Set<OrderStatus>([
     OrderStatus.PendingCancel,

--- a/src/orders/Orders.ts
+++ b/src/orders/Orders.ts
@@ -1,7 +1,6 @@
 import { Subscription, catchError, firstValueFrom, of } from 'rxjs';
 import { IBApiNext, OpenOrder, Order, Contract, OrderCancel, OrderStatus, OrderType } from '@stoqey/ib';
 import IBKRConnection, { isMarketDataOnly } from '../connection/IBKRConnection';
-import identity from 'lodash/identity';
 import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
 import { log, warn } from '../utils/log';
@@ -16,6 +15,8 @@ import { IBKREvents, IBKREVENTS } from '../events';
 import { getContractFilterLabel, isContractAllowed } from '../utils/contract-filter.utils';
 
 const ibkrEvents = IBKREvents.Instance;
+
+const hasValue = (value: unknown): boolean => value !== undefined && value !== null && value !== "";
 
 const ACTIVE_OPEN_ORDER_STATUSES = new Set<OrderStatus>([
     OrderStatus.PendingCancel,
@@ -291,9 +292,9 @@ export class Orders {
             }
         };
 
-        const contract = pickBy(omit(contractDetails.contract, ["primaryExch"]), identity);
+        const contract = pickBy(omit(contractDetails.contract, ["primaryExch"]), hasValue);
 
-        const order = pickBy(orderPlaced, identity);
+        const order = pickBy(orderPlaced, hasValue);
 
         return { order, contract };
     }


### PR DESCRIPTION
### Motivation
- The parsing step previously filtered order and contract objects with a truthy predicate which removed meaningful falsy values like `false` and `0`, causing fields such as `outsideRth` to be dropped. 
- The change aims to preserve explicit user-provided flags (e.g., `outsideRth: false`, `transmit: false`, `lmtPrice: 0`) so they are sent to the IBKR SDK as intended.

### Description
- Replace lodash `identity` filtering with a `hasValue` predicate that only removes `undefined`, `null`, and empty strings, and use it in `pickBy` for both `order` and `contract` in `parseOrder` (`src/orders/Orders.ts`).
- Remove the unused `identity` import and add the `hasValue` helper in `src/orders/Orders.ts`.
- Add a regression test in `src/orders/Orders.active.test.ts` that asserts `outsideRth: false`, `transmit: false`, and `lmtPrice: 0` are preserved and that an empty `primaryExch` is dropped.

### Testing
- Ran `yarn mocha src/orders/Orders.active.test.ts --exit` and the test suite passed (6 passing).
- Ran `yarn lint` and linting completed successfully.
- Risk/tradeoff: the predicate now allows intentional falsy values through to the SDK which is desired behavior, but may change behavior if callers previously relied on those fields being stripped; monitor order submissions for unexpected side effects as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30bfb49f90832991cb9a39e630034e)