### PR TITLE
fix(types): expose ibkr named export for NodeNext

### DIFF
--- a/.ai/changelogs/2026-06-29-nodenext-types.md
+++ b/.ai/changelogs/2026-06-29-nodenext-types.md
@@ -1,0 +1,6 @@
+# 2026-06-29 NodeNext types
+
+- Exported the `ibkr` initializer as a named export in addition to the default export.
+- Added a NodeNext/type-module consumer fixture that type-checks against the built package declarations.
+- Tests run: `./node_modules/.bin/rimraf dist && ./node_modules/.bin/tsc && ./node_modules/.bin/tsc -p test/types/nodenext/tsconfig.json`.
+- Risk: CommonJS runtime remains the published output; full native ESM support is still a follow-up.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { IBApiNextCreationOptions } from '@stoqey/ib';
 import {IBKRConnection} from './connection';
 
 // Export main
-const ibkr = (opt?: Partial<IBApiNextCreationOptions>): Promise<boolean> => {
+export const ibkr = (opt?: Partial<IBApiNextCreationOptions>): Promise<boolean> => {
     return IBKRConnection.Instance.init(opt);
 };
 

--- a/test/types/nodenext/index.ts
+++ b/test/types/nodenext/index.ts
@@ -1,0 +1,9 @@
+import { IBKRConnection, MarketDataManager, ibkr } from "../../../dist/index.js";
+
+const connectionStatus: Promise<boolean> = ibkr();
+const connection = IBKRConnection.Instance;
+const marketDataManager = MarketDataManager.Instance;
+
+void connectionStatus;
+void connection;
+void marketDataManager;

--- a/test/types/nodenext/package.json
+++ b/test/types/nodenext/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/test/types/nodenext/tsconfig.json
+++ b/test/types/nodenext/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
### Motivation

- Fix TypeScript import/shape mismatch for modern Node/TypeScript setups using `module: "NodeNext"` so consumers can import the initializer as a named export without type errors.
- Provide a small, reproducible type-check fixture that validates the built declarations against a `type: "module"` consumer.

### Description

- Export `ibkr` as a named export in addition to the existing default export by changing the initializer to `export const ibkr` in `src/index.ts`.
- Add a NodeNext consumer fixture under `test/types/nodenext/` with `package.json`, `tsconfig.json`, and an `index.ts` that imports `ibkr`, `IBKRConnection`, and `MarketDataManager` from the built output.
- Add an AI changelog entry at `.ai/changelogs/2026-06-29-nodenext-types.md` documenting the change and follow-ups.
- The package still emits CommonJS runtime output; this change narrows the type/import mismatch but does not convert the package to native ESM.

### Testing

- Ran `./node_modules/.bin/rimraf dist && ./node_modules/.bin/tsc && ./node_modules/.bin/tsc -p test/types/nodenext/tsconfig.json`, and the type-check against the NodeNext fixture completed successfully.
- Attempted `yarn build && ./node_modules/.bin/tsc -p test/types/nodenext/tsconfig.json`, which was blocked by a local Yarn lockfile/workspace mismatch and reported `This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile`.
- The fixture `tsconfig.json` sets `skipLibCheck` to avoid unrelated ambient type issues when validating the import/export shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42157055d88329ac626d491aca07bf)