### PR TITLE
fix(getHistoricalData): date-only bars

### DIFF
--- a/.ai/changelogs/2026-06-30-historical-date-bars.md
+++ b/.ai/changelogs/2026-06-30-historical-date-bars.md
@@ -1,0 +1,6 @@
+# 2026-06-30 Historical Date Bars
+
+- summary: fix historical daily/weekly/monthly bar dates returned as `yyyyMMdd`.
+- notable files or areas changed: `src/marketdata/MarketDataManager.ts`, market-data tests.
+- tests run: `yarn mocha src/marketdata/MarketDataManager.getHistoricalData.test.ts --exit`; `yarn marketdata`; `yarn lint`.
+- risks or follow-ups: date-only bars are normalized to UTC midnight.

--- a/src/marketdata/MarketDataManager.getHistoricalData.test.ts
+++ b/src/marketdata/MarketDataManager.getHistoricalData.test.ts
@@ -58,4 +58,15 @@ describe('MarketDataManager - getHistoricalData', () => {
         expect(result).to.have.length(1);
         expect(result[0].date.toISOString()).to.equal('2023-10-06T19:59:59.000Z');
     });
+
+    it('should not normalize malformed date-only bar times', async () => {
+        const { manager, contract } = buildManager([
+            { time: '20250230', open: 104.32, high: 104.32, low: 99.91, close: 101.35, volume: 227874919, WAP: 101.38, count: 774511 },
+        ]);
+
+        const result = await manager.getHistoricalData(contract as any, '', '301 D', BarSizeSetting.DAYS_ONE, WhatToShow.ADJUSTED_LAST, true);
+
+        expect(result).to.have.length(1);
+        expect(Number.isNaN(result[0].date.getTime())).to.be.true;
+    });
 });

--- a/src/marketdata/MarketDataManager.getHistoricalData.test.ts
+++ b/src/marketdata/MarketDataManager.getHistoricalData.test.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { BarSizeSetting, SecType, WhatToShow } from '@stoqey/ib';
+import IBKRConnection from '../connection/IBKRConnection';
+import { MarketDataManager } from './MarketDataManager';
+
+describe('MarketDataManager - getHistoricalData', () => {
+    const originalConnectionInstance = (IBKRConnection as any)._instance;
+
+    afterEach(() => {
+        (IBKRConnection as any)._instance = originalConnectionInstance;
+    });
+
+    const buildManager = (bars: any[]) => {
+        const contract = {
+            symbol: 'NVDA',
+            secType: SecType.STK,
+            exchange: 'SMART',
+            currency: 'USD',
+        };
+        const contractInstrument = {
+            ...contract,
+            conId: 4815747,
+            contract,
+        };
+
+        const manager = new MarketDataManager();
+        manager.getContract = async () => contractInstrument as any;
+
+        (IBKRConnection as any)._instance = {
+            ib: {
+                getHistoricalData: async () => bars,
+            },
+        };
+
+        return { manager, contract };
+    };
+
+    it('should parse date-only daily bars when IBKR returns yyyyMMdd times', async () => {
+        const { manager, contract } = buildManager([
+            { time: '20250417', open: 104.32, high: 104.32, low: 99.91, close: 101.35, volume: 227874919, WAP: 101.38, count: 774511 },
+            { time: '20250421', open: 98.63, high: 99.3, low: 94.91, close: 96.77, volume: 193607618, WAP: 96.2, count: 691760 },
+        ]);
+
+        const result = await manager.getHistoricalData(contract as any, '', '301 D', BarSizeSetting.DAYS_ONE, WhatToShow.ADJUSTED_LAST, true);
+
+        expect(result).to.have.length(2);
+        expect(result[0].date.toISOString()).to.equal('2025-04-17T00:00:00.000Z');
+        expect(result[1].date.toISOString()).to.equal('2025-04-21T00:00:00.000Z');
+    });
+
+    it('should parse Unix-second intraday bars when IBKR returns epoch times', async () => {
+        const { manager, contract } = buildManager([
+            { time: '1696622399', open: 429.5, high: 429.6, low: 429.47, close: 429.51, volume: 3487.38, WAP: 429.532, count: 1090 },
+        ]);
+
+        const result = await manager.getHistoricalData(contract as any, '20231006-20:00:00', '30 S', BarSizeSetting.SECONDS_ONE, WhatToShow.TRADES);
+
+        expect(result).to.have.length(1);
+        expect(result[0].date.toISOString()).to.equal('2023-10-06T19:59:59.000Z');
+    });
+});

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -45,11 +45,14 @@ const parseHistoricalBarDate = (time?: string): Date => {
     }
 
     if (/^\d{8}$/.test(rawTime)) {
-        const year = Number(rawTime.slice(0, 4));
-        const month = Number(rawTime.slice(4, 6)) - 1;
-        const day = Number(rawTime.slice(6, 8));
+        const parsedDate = moment.utc(rawTime, 'YYYYMMDD', true);
 
-        return new Date(Date.UTC(year, month, day));
+        return parsedDate.isValid() ? parsedDate.toDate() : new Date(Number.NaN);
+    }
+
+    const parsedDateTime = moment.utc(rawTime, ['YYYYMMDD HH:mm:ss', 'YYYYMMDD-HH:mm:ss'], true);
+    if (parsedDateTime.isValid()) {
+        return parsedDateTime.toDate();
     }
 
     return new Date(Number(rawTime) * 1000);

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -38,6 +38,23 @@ interface MarketDataItem extends MarketData {
     timestamp?: number;
 }
 
+const parseHistoricalBarDate = (time?: string): Date => {
+    const rawTime = time?.trim();
+    if (!rawTime) {
+        return new Date(Number.NaN);
+    }
+
+    if (/^\d{8}$/.test(rawTime)) {
+        const year = Number(rawTime.slice(0, 4));
+        const month = Number(rawTime.slice(4, 6)) - 1;
+        const day = Number(rawTime.slice(6, 8));
+
+        return new Date(Date.UTC(year, month, day));
+    }
+
+    return new Date(Number(rawTime) * 1000);
+};
+
 export class MarketDataManager extends MkdManager {
     logsNames = logsNames;
     ib: IBApiNext;
@@ -218,7 +235,7 @@ export class MarketDataManager extends MkdManager {
         const [bars, err] = await awaitP(IBKRConnection.Instance.ib.getHistoricalData(contractInstrument, endDateTime, durationStr, barSizeSetting, whatToShow, useRTH, 2));
         if (bars && bars.length > 0) {
             const mkd = bars.map(bar => {
-                const date = new Date(+bar.time * 1000);
+                const date = parseHistoricalBarDate(bar.time);
                 const marketDataItem: MarketData = {
                     instrument: contractInstrument?.contract as Instrument,
                     date,


### PR DESCRIPTION
## Summary

Fixes #144 by parsing IBKR historical bar dates according to the format returned by the API. Daily, weekly, and monthly bars can return `yyyyMMdd` values even when the request asks for Unix-second timestamps, so those values are now normalized to UTC calendar dates instead of being treated as epoch seconds.

## Validation

- `yarn mocha src/marketdata/MarketDataManager.getHistoricalData.test.ts --exit`
- `yarn marketdata`
- `yarn lint`

## Risks / follow-ups

- Date-only bars are normalized to UTC midnight.