### PR TITLE
update(@stoqey/ib): v1.6.3

### DIFF
--- a/.ai/changelogs/2026-06-30-stoqey-ib-1-6-3.md
+++ b/.ai/changelogs/2026-06-30-stoqey-ib-1-6-3.md
@@ -1,0 +1,6 @@
+# 2026-06-30 - @stoqey/ib 1.6.3
+
+- summary: Updated `@stoqey/ib` from `^1.5.2` to `^1.6.3` and refreshed the Yarn v1 lockfile entry.
+- notable files or areas changed: `package.json`, `yarn.lock`, `src/orders/Orders.ts`.
+- tests run: `npx yarn@1.22.22 add @stoqey/ib@^1.6.3 --ignore-engines`; `npm run build`; `npx mocha src/orders/Orders.active.test.ts --exit`; `npm run orders`.
+- risks or follow-ups: `npm run orders` requires a live IBKR connection and failed in this environment before executing assertions.

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "typescript": ">=2.0"
   },
   "dependencies": {
-    "@stoqey/ib": "^1.5.2",
+    "@stoqey/ib": "^1.6.3",
     "asciichart": "^1.5.25",
     "async-mutex": "^0.5.0",
     "debug": "^4.4.0",

--- a/src/orders/Orders.ts
+++ b/src/orders/Orders.ts
@@ -292,7 +292,7 @@ export class Orders {
 
         const contract = pickBy(omit(contractDetails.contract, ["primaryExch"]), hasValue);
 
-        const order = pickBy(orderPlaced, hasValue);
+        const order = pickBy(orderPlaced, hasValue) as Order;
 
         return { order, contract };
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,17 +249,17 @@
   resolved "https://registry.yarnpkg.com/@package-json/types/-/types-0.0.12.tgz#4629e833ba128ed9880b6b7a947633ee22952462"
   integrity sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==
 
-"@stoqey/ib@^1.5.2":
-  version "1.5.2"
-  resolved "https://registry.npmjs.org/@stoqey/ib/-/ib-1.5.2.tgz"
-  integrity sha512-ao2wO6jh3MRWBU8/DBdmWs+RIKJpYGgI+T69/UZ+yOmzW/HEjLLRTNlGggrSC5hGKfzMZJZdtf0px1mW6xYFdw==
+"@stoqey/ib@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@stoqey/ib/-/ib-1.6.3.tgz#b342e38fdcdcec438e1ecfbce23348563a9ac781"
+  integrity sha512-wqR7HD0mxaq80u+AIirTvZLusOWAh6q2+5A1xWR4E0LbsENuopsuPc+OXzoFdJ933FKBJJrKUhTJ8vCCJQrzOA==
   dependencies:
     colors "^1.4.0"
     command-buffer "^0.1.0"
-    dotenv "^16.4.7"
-    eventemitter3 "^5.0.1"
+    dotenv "^17.4.2"
+    eventemitter3 "^5.0.4"
     function-rate-limit "^1.1.0"
-    rxjs "^7.8.1"
+    rxjs "^7.8.2"
 
 "@tybys/wasm-util@^0.10.1":
   version "0.10.2"
@@ -817,6 +817,11 @@ dotenv@^16.4.7:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz"
   integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
 
+dotenv@^17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.4.2.tgz#c07e54a746e11eba021dd9e1047ced5afdc1c034"
+  integrity sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==
+
 emoji-regex@^10.3.0:
   version "10.4.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz"
@@ -986,11 +991,6 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-eventemitter3@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz"
-  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
 eventemitter3@^5.0.4:
   version "5.0.4"
@@ -1534,7 +1534,7 @@ rimraf@^6.1.3:
     glob "^13.0.3"
     package-json-from-dist "^1.0.1"
 
-rxjs@^7.8.1, rxjs@^7.8.2:
+rxjs@^7.8.2:
   version "7.8.2"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz"
   integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==


### PR DESCRIPTION
### Motivation
- Bring `@stoqey/ib` dependency up to the current release to pick up fixes and dependency updates. 
- Ensure the local codebase compiles against the updated typings introduced by the new dependency.

### Description
- Bumped `@stoqey/ib` from `^1.5.2` to `^1.6.3` in `package.json`.
- Updated the Yarn v1 lockfile entries to reflect `@stoqey/ib@1.6.3` and its transitive dependency versions in `yarn.lock`.
- Applied a small type-safe change in `src/orders/Orders.ts` by casting the parsed result to `Order` (`const order = pickBy(orderPlaced, hasValue) as Order;`) to satisfy the updated types.
- Added an AI changelog entry at `.ai/changelogs/2026-06-30-stoqey-ib-1-6-3.md` summarizing the update and follow-ups.

### Testing
- Ran `npx yarn@1.22.22 add @stoqey/ib@^1.6.3 --ignore-engines` to install and refresh the lockfile, which completed successfully.
- Ran `npm run build` and fixed a TypeScript type error by adding the `as Order` cast, after which `npm run build` succeeded.
- Executed unit tests `npx mocha src/orders/Orders.active.test.ts --exit` which passed (`7 passing`).
- Attempted `npm run orders` (integration-style test) which failed in this environment because a live IBKR connection is required and not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43e1323f848329be0f1de574eaee1b)