### PR TITLE
docs(readme): refresh readme realtime docs

### DIFF
--- a/.ai/changelogs/2026-07-01-readme-refresh.md
+++ b/.ai/changelogs/2026-07-01-readme-refresh.md
@@ -1,0 +1,6 @@
+# 2026-07-01 README refresh
+
+- summary: update README usage docs for realtime market data, tick data, emitted events, market-data-only mode, contract filtering, and current order examples.
+- notable files or areas changed: `README.md`.
+- tests run: `git diff --check`.
+- risks or follow-ups: documentation-only change; examples reference the underlying `@stoqey/ib` enums used by the implementation.

--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@
 A modern, TypeScript-based Node.js client for Interactive Brokers (IBKR) that provides a simplified interface to the IBKR API. This package is a wrapper around [@stoqey/ib](https://github.com/stoqey/ib), which implements the official IBKR API. It offers a more developer-friendly way to interact with Interactive Brokers' trading platform, abstracting away the complexity of the underlying API.
 
 ### Key Features
-|       | Feature                                       |
-| :---: | --------------------------------------------- |
-|   ✅   | Accounts                                      |
-|   ✅   | Portfolios                                    |
-|   ✅   | Orders                                        |
-|   ✅   | Historical Data                               |
-|   ✅   | Realtime price updates                        |
-|   ✅   | Contracts (stocks/forex/options/index .e.t.c) |
-|   ⬜️   | Mosaic Market scanner                         |
-|   ⬜️   | News                                          |
+|       | Feature                                                  |
+| :---: | -------------------------------------------------------- |
+|   ✅   | Accounts and account update events                       |
+|   ✅   | Portfolios, positions, and position update events        |
+|   ✅   | Orders, open-order updates, and completed trade events   |
+|   ✅   | Historical bars and historical ticks                     |
+|   ✅   | Realtime bars and tick-by-tick price updates             |
+|   ✅   | Contract lookup and search for stocks/forex/options/etc. |
+|   ✅   | Market-data-only mode for scanners and feeders           |
+|   ✅   | Contract allowlists for orders, positions, and data      |
+|   ⬜️   | Mosaic Market scanner                                    |
+|   ⬜️   | News                                                     |
 
 ## 1. Install
 ```bash
@@ -40,7 +42,14 @@ Create a `.env` in the root dir of your project, set `IBKR_HOST` and `IBKR_PORT`
 IBKR_HOST=localhost
 IBKR_PORT=7497
 IBKR_CLIENT_ID=123
-DEBUG=ibkr* 
+DEBUG=ibkr:*
+```
+
+Optional connection settings:
+
+```sh
+IBKR_RECONNECT_INTERVAL=5000
+IBKR_WATCHDOG_INTERVAL=1
 ```
 
 ### Initialize
@@ -52,53 +61,51 @@ await ibkr();
 // your code
 ```
 
-### Market-data-only mode
-
-Set `MD_ONLY=true` or `IBKR_MD_ONLY=true` before initialization when a process only needs contract lookup and market data:
-
-```sh
-IBKR_MD_ONLY=true
-```
+You can also pass `@stoqey/ib` `IBApiNext` creation options directly:
 
 ```ts
-import ibkr, { MarketDataManager } from '@stoqey/ibkr';
+import ibkr from '@stoqey/ibkr';
 
-await ibkr();
-
-const mkdManager = MarketDataManager.Instance;
-const contractDetails = await mkdManager.getContract({
-  symbol: "ES",
-  secType: "FUT",
+await ibkr({
+  host: "127.0.0.1",
+  port: 7497,
+  reconnectInterval: 5000,
+  connectionWatchdogInterval: 1,
 });
 ```
 
-In market-data-only mode, the package still connects to IBKR and initializes `MarketDataManager`. Contract lookup, contract details, historical data, realtime bars, and tick-by-tick market data remain available.
+### Events
 
-It skips account summary updates, account/portfolio subscriptions, open-order subscriptions, and order/trade event state. Use this for scanners, feeders, and symbol-search clients. Do not use it for execution clients that place orders or need live portfolio/order state.
+`IBKREvents.Instance` is the shared event bus. Managers keep their cached state up to date, and these events let your app react when that state changes:
 
-### Contract filtering
+| Event | Payload | When it emits |
+| --- | --- | --- |
+| `IBKR_CONNECTED` | none | Socket reconnects or finishes connecting |
+| `IBKR_ACCOUNT_UPDATED` | `{ updatedAt }` | Account summary cache changes |
+| `IBKR_POSITIONS_UPDATED` | `{ updatedAt }` | Position cache changes |
+| `IBKR_OPEN_ORDERS_UPDATED` | `{ updatedAt }` | Open-order cache changes |
+| `IBKR_COMPLETED_TRADES_UPDATED` | `{ updatedAt }` | Filled trade cache changes |
+| `IBKR_SAVE_TRADE` | `Trade` | A filled order is converted to a trade |
+| `IBKR_BAR` | `MarketData` | Realtime bar or tick-aggregated bar is cached |
 
-Set `IBKR_CONTRACTS` to a comma-separated allowlist when multiple apps share the same broker session but should only see or trade selected contracts:
+```ts
+import { IBKREvents, IBKREVENTS } from '@stoqey/ibkr';
+import type { MarketData, Trade } from '@stoqey/ibkr';
 
-```env
-IBKR_CONTRACTS=NQ-FUT,AAPL-STK,GC-FUT
+const events = IBKREvents.Instance;
+
+events.on(IBKREVENTS.IBKR_BAR, (bar: MarketData) => {
+  console.log(bar.instrument?.symbol, bar.close);
+});
+
+events.on(IBKREVENTS.IBKR_SAVE_TRADE, (trade: Trade) => {
+  console.log(trade.instrument?.symbol, trade.action, trade.quantity);
+});
 ```
-
-The filter applies to orders, positions, and market data. Futures can be filtered at the symbol/security-type level (`NQ-FUT`) or by expiry (`NQ-FUT-202606` / `NQ-FUT-20260622`).
-
-If one area needs a different allowlist, use a scoped override:
-
-```env
-IBKR_CONTRACTS_ORDERS=NQ-FUT
-IBKR_CONTRACTS_POSITIONS=NQ-FUT,GC-FUT
-IBKR_CONTRACTS_MARKETDATA=*
-```
-
-`*` disables filtering for that scope. Account summary is account-level data from IBKR, so it is intentionally not contract-filtered; use separate accounts, allocation groups, or app-side risk budgets when each app needs isolated buying power.
 
 ### Accounts Summary e.t.c
 ```ts
-import { AccountSummary } from  "@stoqey/ibkr";
+import { AccountSummary, IBKREvents, IBKREVENTS } from "@stoqey/ibkr";
 
 const accountInstance = AccountSummary.Instance;
 
@@ -109,35 +116,63 @@ const accountId = accountSummaries.accountId;
 
 const totalCashValue = accountSummaries.TotalCashValue.value;
 
+IBKREvents.Instance.on(IBKREVENTS.IBKR_ACCOUNT_UPDATED, () => {
+  console.log(accountInstance.accountSummary.NetLiquidation.value);
+});
 ```
+
 ### Portfolios
 ```ts
-import { Portfolios } from  "@stoqey/ibkr";
+import { Portfolios, IBKREvents, IBKREVENTS } from "@stoqey/ibkr";
+
 // Get current portfolios
 const portfolios = Portfolios.Instance;
 
-// positions is automatically updated for you
+// positions returns the latest cached snapshot
 const accountPortfolios = portfolios.positions;
+console.log(accountPortfolios);
 
+IBKREvents.Instance.on(IBKREVENTS.IBKR_POSITIONS_UPDATED, () => {
+  const updatedPortfolios = portfolios.positions;
+  console.log(updatedPortfolios);
+});
 ```
 
-### Historical Data + Realtime price updates
+### Market Data
 
-- Market data
+#### Historical bars
 ```ts
 import { MarketDataManager } from '@stoqey/ibkr';
+import { BarSizeSetting, WhatToShow } from '@stoqey/ib';
 
 // 1. Get market data manager
 const mkdManager = MarketDataManager.Instance;
 
-// 2. Get market data async promise
-const data = await mkdManager.getHistoricalData(contract, endDateTime, durationStr, barSizeSetting, whatToShow,useRTH );
+// 2. Resolve an IBKR contract
+const contract = await mkdManager.getContract({
+  symbol: "AAPL",
+  secType: "STK",
+  exchange: "SMART",
+  currency: "USD",
+});
+
+// 3. Get historical bars
+const data = await mkdManager.getHistoricalData(
+  contract,
+  undefined,
+  "1 D",
+  BarSizeSetting.MINUTES_FIVE,
+  WhatToShow.TRADES,
+  true
+);
 
 ```
 
-- Real-time price updates
+#### Realtime bar updates
 ```ts
 import { MarketDataManager, IBKREvents, IBKREVENTS } from '@stoqey/ibkr';
+import type { MarketData } from '@stoqey/ibkr';
+import { BarSizeSetting, WhatToShow } from '@stoqey/ib';
 
 // 1. Get IBKR events
 const ibkrEvents = IBKREvents.Instance;
@@ -146,15 +181,23 @@ const ibkrEvents = IBKREvents.Instance;
 const mkdManager = MarketDataManager.Instance;
 
 // 3. Request historical data updates
-await mkdManager.getHistoricalDataUpdates(contract,barSizeSetting, whatToShow);
+await mkdManager.getHistoricalDataUpdates(
+  contract,
+  BarSizeSetting.SECONDS_FIVE,
+  WhatToShow.TRADES
+);
 
-// 3. Subscribe for historical data updates
+// 4. Subscribe for realtime bars
 ibkrEvents.on(IBKREVENTS.IBKR_BAR, (bar: MarketData) => {
-     // use the historical data updates here
+  // use the realtime bar here
 });
 
-// 4. get the cached marketdata
-const cachedData = await mkdManager.historicalData(contract, start, end)
+// 5. Get cached market data for a date range
+const cachedData = await mkdManager.historicalData(contract, start, end);
+
+// 6. Get the latest cached quote, or the quote at or before a timestamp
+const latestQuote = await mkdManager.getQuote(contract);
+const pointInTimeQuote = await mkdManager.getQuote(contract, new Date("2026-01-15T15:30:00Z"));
 
 ```
 
@@ -162,7 +205,78 @@ const cachedData = await mkdManager.historicalData(contract, start, end)
 // Unsubscribe from historical data updates
 mkdManager.removeHistoricalDataUpdates(contract);
 ```
-  
+
+#### Tick-by-tick updates
+
+`getTickByTickDataUpdates` subscribes to IBKR all-last ticks, updates portfolio market prices, aggregates ticks into one-second bars, caches those bars, and emits them through `IBKR_BAR`.
+
+```ts
+import { MarketDataManager, IBKREvents, IBKREVENTS } from '@stoqey/ibkr';
+import type { MarketData } from '@stoqey/ibkr';
+
+const ibkrEvents = IBKREvents.Instance;
+const mkdManager = MarketDataManager.Instance;
+
+ibkrEvents.on(IBKREVENTS.IBKR_BAR, (bar: MarketData) => {
+  console.log(bar.date, bar.close, bar.volume);
+});
+
+await mkdManager.getTickByTickDataUpdates(contract);
+
+// Later, unsubscribe
+mkdManager.removeTickByTickDataUpdates(contract);
+```
+
+For historical tick data:
+
+```ts
+const ticks = await mkdManager.getHistoricalTicksLast(
+  contract,
+  new Date("2026-01-15T14:30:00Z"),
+  new Date("2026-01-15T15:30:00Z"),
+  1000,
+  false
+);
+```
+
+#### Market-data-only mode
+
+Set `MD_ONLY=true` or `IBKR_MD_ONLY=true` before initialization when a process only needs contract lookup and market data:
+
+```sh
+IBKR_MD_ONLY=true
+```
+
+In market-data-only mode, the package still connects to IBKR and initializes `MarketDataManager`. Contract lookup, contract details, historical data, realtime bars, historical ticks, and tick-by-tick market data remain available.
+
+It skips account summary updates, account/portfolio subscriptions, open-order subscriptions, and order/trade event state. Use this for scanners, feeders, and symbol-search clients. Do not use it for execution clients that place orders or need live portfolio/order state.
+
+#### Contract filtering
+
+Set `IBKR_CONTRACTS` to a comma-separated allowlist when multiple apps share the same broker session but should only see or trade selected contracts:
+
+```env
+IBKR_CONTRACTS=NQ-FUT,AAPL-STK,GC-FUT
+```
+
+The global filter applies to orders, positions, and market data. Filters are case-insensitive and can match:
+
+- Symbol, such as `AAPL`
+- Symbol/security type, such as `NQ-FUT`
+- Symbol/security type/expiry, such as `NQ-FUT-202606` or `NQ-FUT-20260622`
+- Symbol/security type/exchange, such as `AAPL-STK-SMART`
+- The package symbol key returned by `getSymbolKey`
+
+If one area needs a different allowlist, use a scoped override:
+
+```env
+IBKR_CONTRACTS_ORDERS=NQ-FUT
+IBKR_CONTRACTS_POSITIONS=NQ-FUT,GC-FUT
+IBKR_CONTRACTS_MARKETDATA=*
+```
+
+`IBKR_CONTRACTS_ORDER`, `IBKR_CONTRACTS_POSITION`, and `IBKR_CONTRACTS_MD` are also accepted aliases. `*` disables filtering for that scope. Account summary is account-level data from IBKR, so it is intentionally not contract-filtered; use separate accounts, allocation groups, or app-side risk budgets when each app needs isolated buying power.
+
 ### Contracts
 ```ts
 import { MarketDataManager } from '@stoqey/ibkr';
@@ -196,9 +310,20 @@ const contractDetails = await mkdManager.getContract({
 });
 ```
 
+Use `searchContracts` when you need all matching contract details instead of only the first match:
+
+```ts
+const contracts = await mkdManager.searchContracts({
+  symbol: "ES",
+  secType: "FUT",
+});
+```
+
 ### Orders
 ```ts
-import { Orders, OrderStock, IBKREvents, IBKREVENTS } from '@stoqey/ibkr';
+import { MarketDataManager, Orders, IBKREvents, IBKREVENTS } from '@stoqey/ibkr';
+import type { Trade } from '@stoqey/ibkr';
+import { OrderAction, OrderType } from '@stoqey/ib';
 
 // 1. Get IBKR events
 const ibkrEvents = IBKREvents.Instance;
@@ -207,23 +332,27 @@ const ibkrEvents = IBKREvents.Instance;
 const ordersManager = Orders.Instance;
 
 // 3. Place order
+const mkdManager = MarketDataManager.Instance;
 const contract = await mkdManager.getContract({
-  symbol: ticker,
+  symbol: "AAPL",
   secType: "STK" /* STK, OPT, FUT, etc. */,
   exchange: "SMART" /* SMART, NYSE, NASDAQ, etc. */,
   currency: "USD"  /* USD, EUR, GBP, etc. */
-})
+});
+
+const price = 200;
+const quantity = 1;
 const myOrder = {
-  action, // 1. BUY, 2. SELL
+  action: OrderAction.BUY,
   totalQuantity: quantity,
-  orderType: price ? OrderType.LIMIT : OrderType.MARKET, // 1. MARKET, 2. LIMIT, 3. STOP, etc.
+  orderType: price ? OrderType.LMT : OrderType.MKT,
   ...(price && { lmtPrice: price }),
   transmit: true, // true to submit order immediately, false to save as draft
   outsideRth: false, // true to allow execution outside regular trading hours, false otherwise
   tif: "DAY", // DAY (day order), GTC (good till canceled), IOC (immediate or cancel), etc.
 };
 
-const placedOrder = await ordersManager.placeOrder(contract, myOrder);
+const placed = await ordersManager.placeOrder(contract, myOrder);
 
 // 4. Modify order
 const modifyOrder = await ordersManager.modifyOrder(id, contract, myOrder);
@@ -235,14 +364,22 @@ const orders = ordersManager.orders;
 const trades = ordersManager.trades;
 
 // subscribe for trades, when orders are filled in real time
-ibkrEvents.on(IBKREVENTS.IBKR_SAVE_TRADE, (bar: Trade) => {
-     // use trade here
+ibkrEvents.on(IBKREVENTS.IBKR_SAVE_TRADE, (trade: Trade) => {
+  // use trade here
+});
+
+ibkrEvents.on(IBKREVENTS.IBKR_OPEN_ORDERS_UPDATED, () => {
+  console.log(ordersManager.orders);
+});
+
+ibkrEvents.on(IBKREVENTS.IBKR_COMPLETED_TRADES_UPDATED, () => {
+  console.log(ordersManager.trades);
 });
 
 // other methods e.t.c....
-await ordersManager.cancelOrder(orderId)
+await ordersManager.cancelOrder(orderId);
 
-await ordersManager.cancelAllOrders()        
+await ordersManager.cancelAllOrders({});
 ```
 
 Quickstart Sample App: See this API in action with our companion [Sample Application](https://github.com/stoqey/ibkr-sample).


### PR DESCRIPTION
## Summary
- Refresh README feature list and usage docs for realtime bars, tick-by-tick data, historical ticks, cached quotes, and market-data-only mode.
- Document the newer `IBKREvents` update events for accounts, positions, open orders, completed trades, saved trades, connection, and bars.
- Move contract filtering out of the setup introduction and into the Market Data section with scoped env aliases and matching rules.
- Update order examples to use current `@stoqey/ib` order enums and boolean return wording.

## Tests run
- `git diff --check`

## Risks / follow-ups
- Documentation-only change; examples reference the underlying `@stoqey/ib` enums used by the implementation.