### PR TITLE
fix(marketdata): expose raw historical bars

### DIFF
--- a/.ai/changelogs/2026-07-01-historical-raw.md
+++ b/.ai/changelogs/2026-07-01-historical-raw.md
@@ -1,0 +1,6 @@
+# 2026-07-01 historical raw data
+
+- summary: added `MarketDataManager.getHistoricalDataRaw` to expose IBKR historical bars without wrapper date parsing, including empty raw responses and shared contract resolution for parsed data.
+- notable files or areas changed: `src/marketdata/MarketDataManager.ts`, `src/marketdata/MarketDataManager.getHistoricalData.test.ts`.
+- tests run: `./node_modules/.bin/mocha src/marketdata/MarketDataManager.getHistoricalData.test.ts --exit`; `./node_modules/.bin/tsc --noEmit`; `git diff --check`.
+- risks or follow-ups: raw bars retain IBKR's native `time` labels and are not sorted or converted to `MarketData`.

--- a/src/marketdata/MarketDataManager.getHistoricalData.test.ts
+++ b/src/marketdata/MarketDataManager.getHistoricalData.test.ts
@@ -24,15 +24,23 @@ describe('MarketDataManager - getHistoricalData', () => {
         };
 
         const manager = new MarketDataManager();
-        manager.getContract = async () => contractInstrument as any;
+        let getContractCalls = 0;
+        manager.getContract = async () => {
+            getContractCalls += 1;
+            return contractInstrument as any;
+        };
+        let historicalDataArgs: any[];
 
         (IBKRConnection as any)._instance = {
             ib: {
-                getHistoricalData: async () => bars,
+                getHistoricalData: async (...args: any[]) => {
+                    historicalDataArgs = args;
+                    return bars;
+                },
             },
         };
 
-        return { manager, contract };
+        return { manager, contract, getContractCalls: () => getContractCalls, getHistoricalDataArgs: () => historicalDataArgs };
     };
 
     it('should parse date-only daily bars when IBKR returns yyyyMMdd times', async () => {
@@ -68,5 +76,37 @@ describe('MarketDataManager - getHistoricalData', () => {
 
         expect(result).to.have.length(1);
         expect(Number.isNaN(result[0].date.getTime())).to.be.true;
+    });
+
+    it('should return raw bars when caller requests historical data without parsing', async () => {
+        const bars = [
+            { time: '20260618', open: 208.92, high: 212.72, low: 203.45, close: 210.69, volume: 301767666, WAP: 209.011, count: 1288876 },
+            { time: '20260626', open: 211.44, high: 213.99, low: 191.22, close: 192.53, volume: 369526864, WAP: 200.004, count: 1726049 },
+        ];
+        const { manager, contract, getHistoricalDataArgs } = buildManager(bars);
+
+        const result = await manager.getHistoricalDataRaw(contract as any, '', '6 Y', BarSizeSetting.WEEKS_ONE, WhatToShow.TRADES, true);
+
+        expect(result).to.deep.equal(bars);
+        expect(getHistoricalDataArgs()).to.include.members(['', '6 Y', BarSizeSetting.WEEKS_ONE, WhatToShow.TRADES, true, 2]);
+    });
+
+    it('should return an empty raw bar array when IBKR returns no historical data', async () => {
+        const { manager, contract } = buildManager([]);
+
+        const result = await manager.getHistoricalDataRaw(contract as any, '', '6 Y', BarSizeSetting.WEEKS_ONE, WhatToShow.TRADES, true);
+
+        expect(result).to.deep.equal([]);
+    });
+
+    it('should resolve the contract once when parsing historical data', async () => {
+        const { manager, contract, getContractCalls } = buildManager([
+            { time: '20250417', open: 104.32, high: 104.32, low: 99.91, close: 101.35, volume: 227874919, WAP: 101.38, count: 774511 },
+        ]);
+
+        const result = await manager.getHistoricalData(contract as any, '', '301 D', BarSizeSetting.DAYS_ONE, WhatToShow.ADJUSTED_LAST, true);
+
+        expect(result).to.have.length(1);
+        expect(getContractCalls()).to.equal(1);
     });
 });

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { catchError, lastValueFrom, of, Subscription } from "rxjs";
 import IBKRConnection from '../connection/IBKRConnection';
-import { IBApiNext, Contract, BarSizeSetting, WhatToShow, ContractDetails, HistoricalTickLast } from '@stoqey/ib';
+import { IBApiNext, Contract, BarSizeSetting, WhatToShow, ContractDetails, HistoricalTickLast, Bar } from '@stoqey/ib';
 import { MarketData, TickByTickAllLast } from '../interfaces';
 import awaitP from '../utils/awaitP';
 import { Instrument } from '../interfaces';
@@ -36,6 +36,11 @@ interface CurrentBarData extends Partial<MarketData> {
 
 interface MarketDataItem extends MarketData {
     timestamp?: number;
+}
+
+interface HistoricalRawDataResult {
+    bars: Bar[] | null;
+    contractInstrument: ContractInstrument | null;
 }
 
 const parseHistoricalBarDate = (time?: string): Date => {
@@ -218,24 +223,39 @@ export class MarketDataManager extends MkdManager {
     }
 
 
-    getHistoricalData = async (contract: Contract, endDateTime: string | undefined, durationStr: string, barSizeSetting: BarSizeSetting, whatToShow: WhatToShow, useRTH = false): Promise<MarketData[]> => {
+    private getHistoricalDataRawWithContract = async (contract: Contract, endDateTime: string | undefined, durationStr: string, barSizeSetting: BarSizeSetting, whatToShow: WhatToShow, useRTH = false): Promise<HistoricalRawDataResult> => {
         const [contractInstrument, errContract] = await awaitP(this.getContract(contract));
         if (errContract) {
             warn("getHistoricalData contract err", errContract);
-            return null;
+            return { bars: null, contractInstrument: null };
         }
         if (!contractInstrument) {
             warn("getHistoricalData contract not found", contract);
-            return null;
+            return { bars: null, contractInstrument: null };
         }
 
         const symbol = this.getSymbolKey(contractInstrument);
         if (!isContractAllowed(contractInstrument, "marketdata")) {
-            warn(`${logsNames}.getHistoricalData`, `Contract ${symbol} filtered by IBKR contract filter=${getContractFilterLabel("marketdata")}`);
-            return null;
+            warn(`${logsNames}.getHistoricalDataRaw`, `Contract ${symbol} filtered by IBKR contract filter=${getContractFilterLabel("marketdata")}`);
+            return { bars: null, contractInstrument };
         }
 
         const [bars, err] = await awaitP(IBKRConnection.Instance.ib.getHistoricalData(contractInstrument, endDateTime, durationStr, barSizeSetting, whatToShow, useRTH, 2));
+        if (err) {
+            warn(`getHistoricalDataRaw err ${symbol}`, err);
+        }
+
+        return { bars: bars ?? null, contractInstrument };
+    };
+
+    getHistoricalDataRaw = async (contract: Contract, endDateTime: string | undefined, durationStr: string, barSizeSetting: BarSizeSetting, whatToShow: WhatToShow, useRTH = false): Promise<Bar[]> => {
+        const { bars } = await this.getHistoricalDataRawWithContract(contract, endDateTime, durationStr, barSizeSetting, whatToShow, useRTH);
+
+        return bars;
+    };
+
+    getHistoricalData = async (contract: Contract, endDateTime: string | undefined, durationStr: string, barSizeSetting: BarSizeSetting, whatToShow: WhatToShow, useRTH = false): Promise<MarketData[]> => {
+        const { bars, contractInstrument } = await this.getHistoricalDataRawWithContract(contract, endDateTime, durationStr, barSizeSetting, whatToShow, useRTH);
         if (bars && bars.length > 0) {
             const mkd = bars.map(bar => {
                 const date = parseHistoricalBarDate(bar.time);
@@ -255,9 +275,6 @@ export class MarketDataManager extends MkdManager {
             });
 
             return sortBy(mkd, 'date');
-        }
-        if (err) {
-            warn(`getHistoricalData err ${symbol}`, err);
         }
         return null;
     };


### PR DESCRIPTION
### Motivation
- Callers requested access to IBKR's raw historical bar responses (preserve `bar.time` labels) so they can opt in to interpret period-end labels themselves instead of having the wrapper always parse/normalize dates.

### Description
- Add `MarketDataManager.getHistoricalDataRaw(...)` which returns `Bar[]` from `IBKRConnection.Instance.ib.getHistoricalData` after the standard contract lookup and contract-filter checks.
- Keep existing `getHistoricalData(...)` behavior by sharing the same raw-result path and then applying the existing `parseHistoricalBarDate` -> `MarketData` mapping and sorting.
- Reuse the resolved contract for parsed historical data so `getHistoricalData(...)` does not perform a second contract lookup.
- Preserve empty raw bar arrays as `[]` instead of coercing them to `null`.
- Add unit tests for unchanged raw weekly bars, forwarded historical-data args, empty raw responses, and single contract resolution for parsed data.
- Add `.ai` changelog entry documenting the change and follow-up risk (raw bars retain IBKR-native `time` semantics).

### Testing
- `./node_modules/.bin/mocha src/marketdata/MarketDataManager.getHistoricalData.test.ts --exit` (6 passing)
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45675066648329a63ca648f70b33d0)