### PR TITLE
fix(plotMkdCli): disable CLI plotting calls

### DIFF
--- a/.ai/changelogs/2026-07-04-plot-mkd-cli.md
+++ b/.ai/changelogs/2026-07-04-plot-mkd-cli.md
@@ -1,0 +1,15 @@
+summary
+- Commented out market data calls to plotMkdCli while preserving the call sites for quick reversal.
+
+notable files or areas changed
+- src/marketdata/MarketDataManager.ts
+- src/marketdata/Mkd.ts
+- src/marketdata/Mkd.test.ts
+
+tests run
+- yarn marketdata
+- yarn lint
+- yarn tsc --noEmit
+
+risks or follow-ups
+- CLI chart plotting remains available in src/utils/chart.ts if needed later.

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -12,7 +12,7 @@ import isEmpty from 'lodash/isEmpty';
 import { formatDateStr } from '../utils/time.utils';
 import { getSymbolKey } from '../utils/instrument.utils';
 import { formatDec } from '../utils/data.utils';
-import { plotMkdCli } from '../utils/chart';
+// import { plotMkdCli } from '../utils/chart';
 import sortBy from 'lodash/sortBy';
 import { logBar } from '../utils';
 import { createAggregator } from '../utils/mkd.utils';
@@ -133,7 +133,7 @@ export class MarketDataManager extends MkdManager {
                     const first = historicalData && historicalData[0];
                     const last = (historicalData || [])[historicalData.length - 1];
 
-                    plotMkdCli(historicalData);
+                    // plotMkdCli(historicalData);
 
                     log(`${logsNames}.getHistoricalDataUpdates.getMarketDataLast30Minutes.length`, `${historicalData?.length} data points for ${symbolId} from ${formatDateStr(first?.date)} to ${formatDateStr(last?.date)} @${formatDec(first?.close)} -> @${formatDec(last?.close)} whatToShow=${whatToShow}`);
                     historicalData.forEach((marketDataItem) => {
@@ -384,7 +384,7 @@ export class MarketDataManager extends MkdManager {
                     const first = historicalData && historicalData[0];
                     const last = (historicalData || [])[historicalData.length - 1];
 
-                    plotMkdCli(historicalData);
+                    // plotMkdCli(historicalData);
 
                     log(`${logsNames}.getTickByTickDataUpdates.getMarketDataLast30Minutes.length`, `${historicalData?.length} data points for ${symbolId} from ${formatDateStr(first?.date)} to ${formatDateStr(last?.date)} @${formatDec(first?.close)} -> @${formatDec(last?.close)} whatToShow=TRADES`);
 

--- a/src/marketdata/Mkd.test.ts
+++ b/src/marketdata/Mkd.test.ts
@@ -3,6 +3,7 @@ import 'mocha';
 import { MkdManager } from './Mkd';
 import { Instrument, MarketData } from '../interfaces';
 import { getSymbolKey } from '../utils/instrument.utils';
+import { log } from '../utils/log';
 
 describe('MkdManager with Arrays', () => {
     let manager: MkdManager;
@@ -36,6 +37,32 @@ describe('MkdManager with Arrays', () => {
             expect(result).to.have.length(4); // items 2, 3, 4, 5 (0-indexed)
             expect(result[0].close).to.equal(102); // 3rd item
             expect(result[3].close).to.equal(105); // 6th item
+        });
+
+        it('should not emit CLI chart output when returning historical data', async () => {
+            const messages: string[] = [];
+            const originalEnabled = log.enabled;
+            const originalLog = log.log;
+            log.enabled = true;
+            log.log = (...args: unknown[]) => {
+                messages.push(args.map(String).join(' '));
+            };
+
+            try {
+                const result = await manager.historicalData(
+                    instrument,
+                    new Date('2024-01-15T10:32:00Z'),
+                    new Date('2024-01-15T10:35:00Z')
+                );
+
+                expect(result).to.have.length(4);
+            } finally {
+                log.log = originalLog;
+                log.enabled = originalEnabled;
+            }
+
+            expect(messages).to.have.length(1);
+            expect(messages[0]).to.not.include('\n');
         });
 
         it('should return empty array for non-existent symbol', async () => {

--- a/src/marketdata/Mkd.ts
+++ b/src/marketdata/Mkd.ts
@@ -1,7 +1,7 @@
 import { Instrument, MarketData } from "../interfaces";
 import { Contract } from "@stoqey/ib";
 import { getSymbolKey } from "../utils/instrument.utils";
-import { plotMkdCli } from "../utils/chart";
+// import { plotMkdCli } from "../utils/chart";
 import { log } from "../utils/log";
 import { formatDateStr } from "../utils/time.utils";
 import { formatDec } from "../utils/data.utils";
@@ -171,7 +171,7 @@ export class MkdManager {
         const first = slicedData && slicedData[0];
         const last = (slicedData || [])[slicedData?.length - 1];
 
-        plotMkdCli(slicedData);
+        // plotMkdCli(slicedData);
 
         log(`${this.logsNames}.historicalData`, `${slicedData.length} data points for ${symbol} from ${formatDateStr(first.date)} to ${formatDateStr(last.date)} @${formatDec(first.close)} -> @${formatDec(last.close)}`);
 


### PR DESCRIPTION
## Summary

Comment out the active `plotMkdCli` call sites in market data paths while leaving the commented lines in place for quick reversal. The chart helper itself remains available in `src/utils/chart.ts`.

## Validation

- `yarn marketdata`
- `yarn lint`
- `yarn tsc --noEmit`

## Risks / follow-ups

CLI chart output is now suppressed for historical market data paths unless the commented call sites are restored.