### PR TITLE
fix(marketdata): add resolved snapshot helper

### DIFF
--- a/.ai/changelogs/2026-07-12-market-data-snapshot.md
+++ b/.ai/changelogs/2026-07-12-market-data-snapshot.md
@@ -1,0 +1,6 @@
+# Market data snapshot resolver
+
+- summary: added a high-level MarketDataManager snapshot method that resolves contract details before requesting a snapshot.
+- notable files or areas changed: `src/marketdata/MarketDataManager.ts`, `src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts`.
+- tests run: `pnpm exec mocha src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts --exit`, `pnpm run build`, `pnpm run lint`.
+- risks or follow-ups: none known.

--- a/.ai/changelogs/2026-07-12-market-data-snapshot.md
+++ b/.ai/changelogs/2026-07-12-market-data-snapshot.md
@@ -1,6 +1,6 @@
 # Market data snapshot resolver
 
-- summary: added a high-level MarketDataManager snapshot method that resolves contract details before requesting a snapshot.
+- summary: added a high-level MarketDataManager snapshot method that resolves contract details before requesting a snapshot and hardened it against embedded-contract and contract-filter bypasses.
 - notable files or areas changed: `src/marketdata/MarketDataManager.ts`, `src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts`.
-- tests run: `pnpm exec mocha src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts --exit`, `pnpm run build`, `pnpm run lint`.
-- risks or follow-ups: none known.
+- tests run: `pnpm exec mocha src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts --exit` (4 passing), `pnpm run marketdata` (64 passing), `pnpm run build`, `pnpm run lint`.
+- risks or follow-ups: snapshot requests for contracts outside the market-data allowlist now reject before reaching IBKR.

--- a/src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts
+++ b/src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts
@@ -9,6 +9,34 @@ interface SnapshotCall {
 }
 
 describe('MarketDataManager - getMarketDataSnapshot', () => {
+    const originalContracts = process.env.IBKR_CONTRACTS;
+    const originalMarketDataContracts = process.env.IBKR_CONTRACTS_MARKETDATA;
+    const originalMarketDataContractsAlias = process.env.IBKR_CONTRACTS_MD;
+
+    beforeEach(() => {
+        delete process.env.IBKR_CONTRACTS;
+        delete process.env.IBKR_CONTRACTS_MARKETDATA;
+        delete process.env.IBKR_CONTRACTS_MD;
+    });
+
+    after(() => {
+        if (originalContracts === undefined) {
+            delete process.env.IBKR_CONTRACTS;
+        } else {
+            process.env.IBKR_CONTRACTS = originalContracts;
+        }
+        if (originalMarketDataContracts === undefined) {
+            delete process.env.IBKR_CONTRACTS_MARKETDATA;
+        } else {
+            process.env.IBKR_CONTRACTS_MARKETDATA = originalMarketDataContracts;
+        }
+        if (originalMarketDataContractsAlias === undefined) {
+            delete process.env.IBKR_CONTRACTS_MD;
+        } else {
+            process.env.IBKR_CONTRACTS_MD = originalMarketDataContractsAlias;
+        }
+    });
+
     const buildManager = (resolvedContract: Contract | null) => {
         const manager = new MarketDataManager();
         const snapshot = { last: 5234.25 };
@@ -61,6 +89,44 @@ describe('MarketDataManager - getMarketDataSnapshot', () => {
         ]);
     });
 
+    it('should resolve the top-level query when input contains a nested contract', async () => {
+        // Arrange
+        const query: Partial<Contract> = {
+            symbol: 'ES',
+            secType: SecType.FUT,
+            lastTradeDateOrContractMonth: '202609',
+            currency: 'USD',
+        };
+        const canonicalContract: Contract = {
+            ...query,
+            conId: 123456789,
+            exchange: 'CME',
+            localSymbol: 'ESU6',
+        } as Contract;
+        const decoyContract: Contract = {
+            symbol: 'NQ',
+            secType: SecType.FUT,
+            conId: 987654321,
+            exchange: 'CME',
+            localSymbol: 'NQU6',
+        } as Contract;
+        const contractWithNestedContract = { ...query, contract: decoyContract } as Partial<Contract> & { contract?: unknown };
+        const { manager, snapshotCalls, contractDetailsCalls } = buildManager(canonicalContract);
+
+        // Act
+        await manager.getMarketDataSnapshot(contractWithNestedContract);
+
+        // Assert
+        expect(contractDetailsCalls).to.deep.equal([query]);
+        expect(snapshotCalls).to.deep.equal([
+            {
+                contract: canonicalContract,
+                genericTickList: '',
+                regulatorySnapshot: false,
+            },
+        ]);
+    });
+
     it('should reject without requesting a snapshot when contract resolution fails', async () => {
         const incompleteContract: Partial<Contract> = {
             symbol: 'ES',
@@ -77,6 +143,36 @@ describe('MarketDataManager - getMarketDataSnapshot', () => {
             expect((error as Error).message).to.contain('Unable to resolve contract for market data snapshot');
         }
 
+        expect(snapshotCalls).to.deep.equal([]);
+    });
+
+    it('should reject without requesting a snapshot when the resolved contract is filtered', async () => {
+        // Arrange
+        const incompleteContract: Partial<Contract> = {
+            symbol: 'ES',
+            secType: SecType.FUT,
+            lastTradeDateOrContractMonth: '202609',
+            currency: 'USD',
+        };
+        const canonicalContract: Contract = {
+            ...incompleteContract,
+            conId: 123456789,
+            exchange: 'CME',
+            localSymbol: 'ESU6',
+        } as Contract;
+        process.env.IBKR_CONTRACTS_MARKETDATA = 'NQ-FUT';
+        const { manager, snapshotCalls, contractDetailsCalls } = buildManager(canonicalContract);
+
+        // Act
+        try {
+            await manager.getMarketDataSnapshot(incompleteContract);
+            expect.fail('Expected getMarketDataSnapshot to reject');
+        } catch (error) {
+            expect((error as Error).message).to.contain('Contract ES-FUT-202609 filtered by IBKR contract filter=NQ-FUT');
+        }
+
+        // Assert
+        expect(contractDetailsCalls).to.deep.equal([incompleteContract]);
         expect(snapshotCalls).to.deep.equal([]);
     });
 });

--- a/src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts
+++ b/src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { Contract, SecType } from '@stoqey/ib';
+import { MarketDataManager } from './MarketDataManager';
+
+interface SnapshotCall {
+    contract: Contract;
+    genericTickList: string;
+    regulatorySnapshot: boolean;
+}
+
+describe('MarketDataManager - getMarketDataSnapshot', () => {
+    const buildManager = (resolvedContract: Contract | null) => {
+        const manager = new MarketDataManager();
+        const snapshot = { last: 5234.25 };
+        const snapshotCalls: SnapshotCall[] = [];
+        const contractDetailsCalls: Partial<Contract>[] = [];
+
+        manager.ib = {
+            getContractDetails: async (contract: Partial<Contract>) => {
+                contractDetailsCalls.push(contract);
+                if (!resolvedContract) {
+                    return [];
+                }
+
+                return [{ contract: resolvedContract }];
+            },
+            getMarketDataSnapshot: async (contract: Contract, genericTickList: string, regulatorySnapshot: boolean) => {
+                snapshotCalls.push({ contract, genericTickList, regulatorySnapshot });
+                return snapshot;
+            },
+        } as any;
+
+        return { manager, snapshot, snapshotCalls, contractDetailsCalls };
+    };
+
+    it('should resolve an incomplete futures contract before requesting a snapshot', async () => {
+        const incompleteContract: Partial<Contract> = {
+            symbol: 'ES',
+            secType: SecType.FUT,
+            lastTradeDateOrContractMonth: '202609',
+            currency: 'USD',
+        };
+        const canonicalContract: Contract = {
+            ...incompleteContract,
+            conId: 123456789,
+            exchange: 'CME',
+            localSymbol: 'ESU6',
+        } as Contract;
+        const { manager, snapshot, snapshotCalls, contractDetailsCalls } = buildManager(canonicalContract);
+
+        const result = await manager.getMarketDataSnapshot(incompleteContract, '233', true);
+
+        expect(result).to.equal(snapshot);
+        expect(contractDetailsCalls).to.deep.equal([incompleteContract]);
+        expect(snapshotCalls).to.deep.equal([
+            {
+                contract: canonicalContract,
+                genericTickList: '233',
+                regulatorySnapshot: true,
+            },
+        ]);
+    });
+
+    it('should reject without requesting a snapshot when contract resolution fails', async () => {
+        const incompleteContract: Partial<Contract> = {
+            symbol: 'ES',
+            secType: SecType.FUT,
+            lastTradeDateOrContractMonth: '202609',
+            currency: 'USD',
+        };
+        const { manager, snapshotCalls } = buildManager(null);
+
+        try {
+            await manager.getMarketDataSnapshot(incompleteContract);
+            expect.fail('Expected getMarketDataSnapshot to reject');
+        } catch (error) {
+            expect((error as Error).message).to.contain('Unable to resolve contract for market data snapshot');
+        }
+
+        expect(snapshotCalls).to.deep.equal([]);
+    });
+});

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -522,12 +522,20 @@ export class MarketDataManager extends MkdManager {
     };
 
     getMarketDataSnapshot = async (contract: Partial<Contract>, genericTickList = '', regulatorySnapshot = false): Promise<MutableMarketData> => {
-        const contractInstrument = await this.getContract(contract);
-        if (!contractInstrument?.contract) {
+        const { contract: _ignored, ...query } = (contract || {}) as Partial<Contract> & { contract?: unknown };
+        const resolved = await this.getContract(query);
+        if (!resolved?.contract) {
             throw new Error(`Unable to resolve contract for market data snapshot: ${JSON.stringify(contract || {})}`);
         }
 
-        return this.ib.getMarketDataSnapshot(contractInstrument.contract, genericTickList, regulatorySnapshot);
+        const symbol = this.getSymbolKey(resolved.contract);
+        if (!isContractAllowed(resolved.contract, "marketdata")) {
+            const filter = getContractFilterLabel("marketdata");
+            warn(`${logsNames}.getMarketDataSnapshot`, `Contract ${symbol} filtered by IBKR contract filter=${filter}`);
+            throw new Error(`Contract ${symbol} filtered by IBKR contract filter=${filter}`);
+        }
+
+        return this.ib.getMarketDataSnapshot(resolved.contract, genericTickList, regulatorySnapshot);
     }
 
     getContract = async (contract: Partial<Contract | any>): Promise<ContractInstrument> => {

--- a/src/marketdata/MarketDataManager.ts
+++ b/src/marketdata/MarketDataManager.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { catchError, lastValueFrom, of, Subscription } from "rxjs";
 import IBKRConnection from '../connection/IBKRConnection';
-import { IBApiNext, Contract, BarSizeSetting, WhatToShow, ContractDetails, HistoricalTickLast, Bar } from '@stoqey/ib';
+import { IBApiNext, Contract, BarSizeSetting, WhatToShow, ContractDetails, HistoricalTickLast, Bar, MutableMarketData } from '@stoqey/ib';
 import { MarketData, TickByTickAllLast } from '../interfaces';
 import awaitP from '../utils/awaitP';
 import { Instrument } from '../interfaces';
@@ -520,6 +520,15 @@ export class MarketDataManager extends MkdManager {
         this.PendingTickByTickDataUpdates.delete(symbolId);
         this.currentTickBarData.delete(symbolId);
     };
+
+    getMarketDataSnapshot = async (contract: Partial<Contract>, genericTickList = '', regulatorySnapshot = false): Promise<MutableMarketData> => {
+        const contractInstrument = await this.getContract(contract);
+        if (!contractInstrument?.contract) {
+            throw new Error(`Unable to resolve contract for market data snapshot: ${JSON.stringify(contract || {})}`);
+        }
+
+        return this.ib.getMarketDataSnapshot(contractInstrument.contract, genericTickList, regulatorySnapshot);
+    }
 
     getContract = async (contract: Partial<Contract | any>): Promise<ContractInstrument> => {
         if ((contract as ContractInstrument)?.contract) {


### PR DESCRIPTION
### Motivation
- Provide a high-level snapshot method that accepts a partial `Contract`, ensures the contract is resolved via IBKR `getContractDetails` so callers don't need to supply full contract identity, and fail early if resolution produces no canonical contract.

### Description
- Add `MarketDataManager.getMarketDataSnapshot(contract: Partial<Contract>, genericTickList?, regulatorySnapshot?)` which resolves the input via existing `getContract`/`getContractDetails`, throws a clear error when resolution fails, and calls the low-level `ib.getMarketDataSnapshot` with the resolved `contract`, returning the original `MutableMarketData` shape.

### Follow-up fixes
- Discard a caller-supplied nested `.contract` before resolution, so the low-level snapshot call always receives the canonical IBKR-resolved contract.
- Enforce the established `marketdata` contract allowlist after resolution; blocked snapshots log and reject before a request reaches IBKR.
- Add focused regression tests for both bypass paths and isolate contract-filter environment state per test.

### Testing
- `pnpm exec mocha src/marketdata/MarketDataManager.getMarketDataSnapshot.test.ts --exit` — 4 passing
- `pnpm run marketdata` — 64 passing
- `pnpm run build`
- `pnpm run lint`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a541e048328832996450d948957539a)