### PR TITLE
fix(marketdata): serialize historical endpoints in UTC

### DIFF
--- a/.ai/changelogs/2026-07-19-utc-historical-bars.md
+++ b/.ai/changelogs/2026-07-19-utc-historical-bars.md
@@ -1,0 +1,6 @@
+# UTC historical bars
+
+- Summary: serialize 5-second-bar historical backfill endpoints in UTC.
+- Files: `src/marketdata/ibkr.utils.ts` (including the tested timestamp formatter), `src/marketdata/ibkr.utils.test.ts`.
+- Tests: `pnpm marketdata`, `pnpm lint`, `pnpm build`; local Gateway probe returned 7,200 NFLX bars from `2026-06-03T10:00:00Z` through `2026-06-03T19:59:55Z` (5,058 positive-volume, 2,142 zero-volume).
+- Risks/follow-ups: IBKR may revise historical volume counts.

--- a/src/marketdata/ibkr.utils.test.ts
+++ b/src/marketdata/ibkr.utils.test.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { formatHistoricalEndDateTime } from './ibkr.utils';
+
+describe('IBKR historical data end timestamp', () => {
+    it('should serialize a 4:00PM EDT date as UTC', () => {
+        const localDate = new Date('2026-06-03T16:00:00-04:00');
+
+        const endDateTime = formatHistoricalEndDateTime(localDate);
+
+        expect(endDateTime).to.equal('20260603-20:00:00');
+    });
+});

--- a/src/marketdata/ibkr.utils.ts
+++ b/src/marketdata/ibkr.utils.ts
@@ -15,6 +15,8 @@ import { GetHistoricalData, getSymbolKey } from '../utils/instrument.utils';
 
 const throttleDelay = 500;
 
+export const formatHistoricalEndDateTime = (date: Date): string => moment.utc(date).format('YYYYMMDD-HH:mm:ss');
+
 export const getHistoricalData = async (opt: GetHistoricalData): Promise<MarketData[]> => {
     const { instrument, startDate, endDate, whatToShow } = opt;
     const saveToDb = opt?.saveToDb;
@@ -96,7 +98,7 @@ export async function getSecondsHistoricalDataFromIb(
         const symbolKey = getSymbolKey(contract);
         for (const x of new Array(count).fill('x')) {
             date = new Date(date.setHours(date.getHours() - 1));
-            const endDateTime = moment(date).format('yyyyMMDD-HH:mm:ss');
+            const endDateTime = formatHistoricalEndDateTime(date);
             log(`ibApi.reqHistoricalData -----> ${symbolKey}`, endDateTime);
 
             const timeout = 1000 * 50; // 50 seconds


### PR DESCRIPTION
## Summary

Serialize 5-second historical-backfill request endpoints as UTC and cover the wire format with a unit test.

## Why

The backfill builds local `Date` endpoints but IBKR interprets hyphenated timestamps as UTC. Local serialization requested a window several hours too early, inflating zero-volume bars and lowering persisted volume-bearing rows.

## Validation

- `pnpm marketdata` (65 passing)
- `pnpm lint`
- `pnpm build`
- Local Gateway probe at `127.0.0.1:7497` (client ID 45): 7,200 NFLX bars, 5,058 positive-volume; `2026-06-03T10:00:00Z` through `2026-06-03T19:59:55Z`

## Risks / follow-ups

IBKR may revise historical volume counts, though the expected UTC window and total bar count are verified.