### PR TITLE
fix(marketdata): preserve UTC historical day bounds

### DIFF
--- a/.ai/changelogs/2026-07-19-utc-historical-range-boundary.md
+++ b/.ai/changelogs/2026-07-19-utc-historical-range-boundary.md
@@ -1,0 +1,6 @@
+# UTC historical range boundary
+
+- Summary: preserve UTC calendar days while anchoring IBKR historical endpoints to the New York trading session.
+- Files: `src/marketdata/ibkr.utils.ts`, `src/marketdata/ibkr.utils.test.ts`.
+- Tests: `pnpm marketdata`, `pnpm lint`, `pnpm exec tsc --noEmit`.
+- Risks/follow-ups: Existing hourly request windows and market-close times remain unchanged.

--- a/src/marketdata/ibkr.utils.test.ts
+++ b/src/marketdata/ibkr.utils.test.ts
@@ -1,12 +1,45 @@
 import { expect } from 'chai';
-import { formatHistoricalEndDateTime } from './ibkr.utils';
+import { SecType } from '@stoqey/ib';
+import { formatHistoricalEndDateTime, getHistoricalData } from './ibkr.utils';
+import MarketDataManager from './MarketDataManager';
 
 describe('IBKR historical data end timestamp', () => {
+    const originalTimeZone = process.env.TZ;
+    const originalMarketDataManager = (MarketDataManager as any)._instance;
+
+    afterEach(() => {
+        if (originalTimeZone === undefined) {
+            delete process.env.TZ;
+        } else {
+            process.env.TZ = originalTimeZone;
+        }
+        (MarketDataManager as any)._instance = originalMarketDataManager;
+    });
+
     it('should serialize a 4:00PM EDT date as UTC', () => {
         const localDate = new Date('2026-06-03T16:00:00-04:00');
 
         const endDateTime = formatHistoricalEndDateTime(localDate);
 
         expect(endDateTime).to.equal('20260603-20:00:00');
+    });
+
+    it('should request the UTC calendar days when dates are midnight in a Toronto process', async () => {
+        process.env.TZ = 'America/Toronto';
+        const endDateTimes: string[] = [];
+        (MarketDataManager as any)._instance = {
+            getHistoricalData: async (_contract: unknown, endDateTime: string) => {
+                endDateTimes.push(endDateTime);
+                return [];
+            },
+        };
+
+        await getHistoricalData({
+            instrument: { symbol: 'NVDA', secType: SecType.STK } as any,
+            startDate: new Date('2026-06-02T00:00:00.000Z'),
+            endDate: new Date('2026-06-03T00:00:00.000Z'),
+        });
+
+        expect(endDateTimes).to.deep.equal(['20260602-20:30:00', '20260603-20:30:00']);
     });
 });

--- a/src/marketdata/ibkr.utils.ts
+++ b/src/marketdata/ibkr.utils.ts
@@ -14,8 +14,25 @@ import { GetHistoricalData, getSymbolKey } from '../utils/instrument.utils';
  */
 
 const throttleDelay = 500;
+const exchangeTimeZoneFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    timeZoneName: 'longOffset',
+});
 
 export const formatHistoricalEndDateTime = (date: Date): string => moment.utc(date).format('YYYYMMDD-HH:mm:ss');
+
+const createExchangeDate = (dayDate: Date, hour: number, minute: number, second: number): Date => {
+    const utcDate = new Date(Date.UTC(dayDate.getUTCFullYear(), dayDate.getUTCMonth(), dayDate.getUTCDate(), hour, minute, second));
+    const offsetMatch = exchangeTimeZoneFormatter.format(utcDate).match(/GMT([+-])(\d{2}):(\d{2})/);
+
+    if (!offsetMatch) {
+        throw new Error('Unable to determine the America/New_York timezone offset');
+    }
+
+    const offset = (parseInt(offsetMatch[2], 10) * 60 + parseInt(offsetMatch[3], 10)) * 60 * 1000;
+
+    return new Date(utcDate.getTime() - (offsetMatch[1] === '+' ? offset : -offset));
+};
 
 export const getHistoricalData = async (opt: GetHistoricalData): Promise<MarketData[]> => {
     const { instrument, startDate, endDate, whatToShow } = opt;
@@ -41,12 +58,12 @@ export const getHistoricalData = async (opt: GetHistoricalData): Promise<MarketD
         while (dayDate <= endDateLoop) {
             const dayData = await getSecondsHistoricalDataFromIb(instrument, dayDate, whatToShow);
             if (isEmpty(dayData)) {
-                dayDate.setDate(dayDate.getDate() + 1);
+                dayDate.setUTCDate(dayDate.getUTCDate() + 1);
                 continue;
             }
             await save(dayData);
             data = data.concat(dayData);
-            dayDate.setDate(dayDate.getDate() + 1);
+            dayDate.setUTCDate(dayDate.getUTCDate() + 1);
         }
         return data;
     }
@@ -72,12 +89,12 @@ export async function getSecondsHistoricalDataFromIb(
         }
 
         // Default to 8 - 5:30
-        let date = new Date(dayDate.getFullYear(), dayDate.getMonth(), dayDate.getDate(), 17, 30, 0); // set date to 5:30 when market closes
+        let date = createExchangeDate(dayDate, 17, 30, 0); // set date to 5:30 when market closes
         let count = 10; // 10 hours back
 
         if (contract?.secType === SecType.FUT) {
             // futures e.t.c ...
-            date = new Date(dayDate.getFullYear(), dayDate.getMonth(), dayDate.getDate(), 23, 59, 0);
+            date = createExchangeDate(dayDate, 23, 59, 0);
             count = 23; // 23 hours back
         }
 
@@ -97,7 +114,7 @@ export async function getSecondsHistoricalDataFromIb(
 
         const symbolKey = getSymbolKey(contract);
         for (const x of new Array(count).fill('x')) {
-            date = new Date(date.setHours(date.getHours() - 1));
+            date = new Date(date.setUTCHours(date.getUTCHours() - 1));
             const endDateTime = formatHistoricalEndDateTime(date);
             log(`ibApi.reqHistoricalData -----> ${symbolKey}`, endDateTime);
 


### PR DESCRIPTION
## Summary

Preserves the UTC calendar day supplied by RDX while retaining the 17:30 America/New_York trading-session anchor for IBKR historical requests.

## Root cause

The utility derived the anchor with the worker's local date getters and constructor. A UTC-midnight input could therefore select the prior calendar day, and the first UTC-only correction shifted the exchange-local 17:30 anchor to 17:30 UTC.

## Impact

For `2026-06-02T00:00:00Z`, the first stock request now correctly ends at `20260602-20:30:00` UTC (16:30 EDT), preserving the intended ten-hour trading-session window.

## Validation

- `pnpm marketdata`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- Local IBKR Gateway probe with client ID 45 for AAPL on 2026-06-02: first request `20260602-20:30:00`; 7,200 five-second bars returned.

## Risks / follow-ups

The existing hourly request count and durations are unchanged. The exchange timezone is explicitly `America/New_York` for these historical anchors.